### PR TITLE
feat(jit): add cross-platform JIT support (Windows x64, ARM64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  linux:
+    name: Linux (all checks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ci-
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Check (default features)
+        run: cargo check
+
+      - name: Check (all features)
+        run: cargo check --features full
+
+      - name: Clippy
+        run: cargo clippy --features full --all-targets -- -D warnings
+
+      - name: Run tests (default features)
+        run: cargo test
+
+      - name: Run tests (all features)
+        run: cargo test --features full
+
+      - name: Build documentation
+        run: cargo doc --features full --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ci-
+            ${{ runner.os }}-cargo-
+
+      - name: Check (all features)
+        run: cargo check --features full
+
+      - name: Run tests (all features)
+        run: cargo test --features full
+
+  macos:
+    name: macOS (Intel)
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ci-
+            ${{ runner.os }}-cargo-
+
+      - name: Check (all features)
+        run: cargo check --features full
+
+      - name: Run tests (all features)
+        run: cargo test --features full
+
+  msrv:
+    name: MSRV (1.70)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.70
+        uses: dtolnay/rust-toolchain@1.70
+
+      - name: Check MSRV
+        run: cargo check --features full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,13 @@ jobs:
         run: cargo test --features full
 
   msrv:
-    name: MSRV (1.70)
+    name: MSRV (1.83)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.70
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install Rust 1.83
+        uses: dtolnay/rust-toolchain@1.83
 
       - name: Check MSRV
         run: cargo check --features full

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -61,6 +61,39 @@ jobs:
       - name: Test (full)
         run: cargo test --features full
 
+  linux-arm64:
+    name: Linux (ARM64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-arm64-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-cargo-jit-
+            ${{ runner.os }}-arm64-cargo-
+
+      - name: Check (no features)
+        run: cargo check --no-default-features
+
+      - name: Check (jit only)
+        run: cargo check --features jit
+
+      - name: Test (no JIT)
+        run: cargo test --no-default-features
+
+      - name: Test (JIT only)
+        run: cargo test --features jit
+
   windows:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -1,0 +1,116 @@
+name: JIT CI
+
+on:
+  push:
+    branches:
+      - '**/jit/**'
+      - 'jit/**'
+      - '**/jit'
+      - 'jit-*'
+      - '*-jit'
+      - '*-jit-*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/jit/**'
+      - 'src/vm/*/jit/**'
+      - 'src/nfa/tagged/jit/**'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-jit-
+            ${{ runner.os }}-cargo-
+
+      - name: Check (no features)
+        run: cargo check --no-default-features
+
+      - name: Check (jit only)
+        run: cargo check --features jit
+
+      - name: Check (full)
+        run: cargo check --features full
+
+      - name: Test (no JIT)
+        run: cargo test --no-default-features
+
+      - name: Test (JIT only)
+        run: cargo test --features jit
+
+      - name: Test (full)
+        run: cargo test --features full
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-jit-
+            ${{ runner.os }}-cargo-
+
+      - name: Check (full)
+        run: cargo check --features full
+
+      - name: Test (full)
+        run: cargo test --features full
+
+  macos:
+    name: macOS (Intel)
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-jit-
+            ${{ runner.os }}-cargo-
+
+      - name: Check (full)
+        run: cargo check --features full
+
+      - name: Test (full)
+        run: cargo test --features full

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Test (full)
         run: cargo test --features full
 
-  macos:
-    name: macOS (Intel)
+  macos-intel:
+    name: macOS (Intel x86_64)
     runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4
@@ -104,13 +104,65 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-intel-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-jit-
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-intel-cargo-jit-
+            ${{ runner.os }}-intel-cargo-
 
       - name: Check (full)
         run: cargo check --features full
+
+      - name: Test (full)
+        run: cargo test --features full
+
+  macos-arm64:
+    name: macOS (ARM64 Apple Silicon)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-arm64-cargo-jit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-cargo-jit-
+            ${{ runner.os }}-arm64-cargo-
+
+      - name: Check (no features)
+        run: cargo check --no-default-features
+
+      - name: Check (jit only)
+        run: cargo check --features jit
+
+      - name: Check (full)
+        run: cargo check --features full
+
+      - name: Test (no JIT)
+        run: cargo test --no-default-features
+
+      - name: Test (JIT only) - Debug ARM64
+        run: |
+          echo "=== Running JIT tests on ARM64 ==="
+          echo "Architecture: $(uname -m)"
+          cargo test --features jit -- --test-threads=1 2>&1 || {
+            echo "=== JIT tests failed, running individual test files ==="
+            cargo test --features jit --lib -- --test-threads=1 || true
+            cargo test --features jit --test api -- --test-threads=1 || true
+            cargo test --features jit --test engines -- --test-threads=1 || true
+            cargo test --features jit --test features -- --test-threads=1 || true
+            cargo test --features jit --test patterns -- --test-threads=1 || true
+            cargo test --features jit --test unicode -- --test-threads=1 || true
+            echo "=== Individual test runs complete ==="
+            exit 1
+          }
 
       - name: Test (full)
         run: cargo test --features full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regexr"
-version = "0.1.0"
+version = "0.1.0-beta.3"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regexr"
-version = "0.1.0"
+version = "0.1.0-beta.3"
 edition = "2021"
 authors = ["Farhan Syah"]
 description = "A high-performance regex engine built from scratch with JIT compilation and SIMD acceleration"

--- a/README.md
+++ b/README.md
@@ -163,8 +163,19 @@ assert_eq!(result, "abc NUM def NUM");
 ## Feature Flags
 
 - `simd` (default): Enables SIMD-accelerated literal search
-- `jit`: Enables JIT compilation for x86-64
+- `jit`: Enables JIT compilation (x86-64 and ARM64)
 - `full`: Enables both JIT and SIMD
+
+### Platform Support
+
+| Platform | JIT Support | SIMD Support |
+|----------|-------------|--------------|
+| Linux x86-64 | ✓ | ✓ (AVX2) |
+| Linux ARM64 | ✓ | ✗ |
+| macOS x86-64 | ✓ | ✓ (AVX2) |
+| macOS ARM64 (Apple Silicon) | ✓ | ✗ |
+| Windows x86-64 | ✓ | ✓ (AVX2) |
+| Other | ✗ | ✗ |
 
 Build without default features for a minimal installation:
 

--- a/benches/utils/test_data.rs
+++ b/benches/utils/test_data.rs
@@ -78,7 +78,7 @@ pub fn get_test_data() -> &'static TestDataCache {
 }
 
 fn generate_email_data(target_size: usize) -> String {
-    let valid_emails = vec![
+    let valid_emails = [
         "john.doe@example.com",
         "jane_smith@company.org",
         "test+tag@subdomain.example.co.uk",
@@ -87,7 +87,7 @@ fn generate_email_data(target_size: usize) -> String {
         "admin@localhost.localdomain",
     ];
 
-    let invalid_emails = vec![
+    let invalid_emails = [
         "not-an-email",
         "@example.com",
         "missing@domain",
@@ -113,7 +113,7 @@ fn generate_email_data(target_size: usize) -> String {
 }
 
 fn generate_url_data(target_size: usize) -> String {
-    let urls = vec![
+    let urls = [
         "https://www.example.com/path/to/resource",
         "http://subdomain.test.org:8080/api/v1/users?id=123",
         "https://github.com/user/repo/blob/main/src/file.rs",
@@ -134,8 +134,8 @@ fn generate_url_data(target_size: usize) -> String {
 }
 
 fn generate_log_data(target_size: usize) -> String {
-    let levels = vec!["INFO", "WARNING", "ERROR", "CRITICAL", "DEBUG"];
-    let messages = vec![
+    let levels = ["INFO", "WARNING", "ERROR", "CRITICAL", "DEBUG"];
+    let messages = [
         "Request processed successfully",
         "Connection timeout after 30s",
         "Database query failed",
@@ -206,7 +206,7 @@ fn generate_ip_data(target_size: usize) -> String {
 }
 
 fn generate_html_data(target_size: usize) -> String {
-    let tags = vec![
+    let tags = [
         "<div class=\"container\">",
         "<p>Some paragraph text</p>",
         "<a href=\"/link\">Click here</a>",
@@ -229,7 +229,7 @@ fn generate_html_data(target_size: usize) -> String {
 }
 
 fn generate_text_data(target_size: usize) -> String {
-    let words = vec![
+    let words = [
         "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "and", "then", "runs",
         "through", "forest", "near", "river", "where", "birds", "sing", "their", "morning",
         "songs",
@@ -247,7 +247,7 @@ fn generate_text_data(target_size: usize) -> String {
 }
 
 fn generate_code_data(target_size: usize) -> String {
-    let code_snippets = vec![
+    let code_snippets = [
         r#"let x = "hello world";"#,
         r#"const y = 'single quoted string';"#,
         r#"var z = "escaped \"quotes\" inside";"#,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ Pattern String → AST → HIR → NFA → Engine-Specific Representation
 
 ### JIT Engines (Native Code Generation)
 
-Available on x86-64 with the `jit` feature.
+Available on x86-64 (Linux, macOS, Windows) and ARM64 (Linux, macOS) with the `jit` feature.
 
 #### DFA JIT (`src/jit/`)
 - Compiles DFA to native machine code
@@ -245,7 +245,7 @@ full = ["jit", "simd"]
 ```
 
 - **default**: SIMD acceleration only
-- **jit**: Adds JIT compilation (x86-64 only)
+- **jit**: Adds JIT compilation (x86-64 and ARM64)
 - **full**: Both JIT and SIMD
 
 ### Conditional Compilation
@@ -253,11 +253,11 @@ full = ["jit", "simd"]
 JIT engines use conditional compilation:
 
 ```rust
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod jit;
 ```
 
-This ensures JIT code is only compiled on supported platforms.
+This ensures JIT code is only compiled on supported platforms (x86-64 and ARM64).
 
 ## Performance Considerations
 

--- a/docs/engine_structure.md
+++ b/docs/engine_structure.md
@@ -32,7 +32,7 @@ src/{engine_type}/{engine_name}/
 │   ├── mod.rs
 │   ├── {name}.rs       # JIT struct and public API
 │   ├── x86_64.rs       # x86-64 code generation
-│   ├── aarch64.rs      # ARM64 code generation (future)
+│   ├── aarch64.rs      # ARM64 code generation
 │   └── helpers.rs      # Extern helper functions for JIT
 └── *.rs                # [optional] Engine-specific files as needed
 ```
@@ -100,7 +100,7 @@ src/vm/shift_or/
 
 ### JIT-Gated
 ```rust
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod jit;
 ```
 
@@ -133,7 +133,7 @@ pub use aarch64::compile;
 pub mod interpreter;
 mod engine;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod jit;
 
 // Re-exports
@@ -198,10 +198,10 @@ The `src/jit/mod.rs` module exists for backwards compatibility and convenience. 
 
 ```rust
 // Re-export from canonical locations
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use crate::nfa::tagged::jit::{TaggedNfaJit, compile_tagged_nfa};
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use crate::dfa::lazy::jit::{DfaJit, compile_dfa};
 ```
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -265,7 +265,7 @@ JIT compilation is beneficial when:
 
 ### JIT Requirements
 
-- Only available on x86-64 architecture
+- Available on x86-64 (Linux, macOS, Windows) and ARM64 (Linux, macOS)
 - Requires `jit` feature flag
 - Automatically falls back to interpreted engines if compilation fails
 
@@ -506,15 +506,21 @@ Ensure the engine matches your expectations for the pattern type.
 
 ### Current Limitations
 
-1. **JIT**: Only available on x86-64 architecture
+1. **SIMD**: Only available on x86-64 with AVX2 support
 2. **Multiline mode**: Currently `.` never matches newline
 3. **Backreferences**: Cannot be combined with JIT DFA (uses BacktrackingJit instead)
 4. **Variable-width lookbehind**: Limited support (fixed-width lookbehind only)
 
 ### Platform Support
 
-- **x86-64**: All features including JIT
-- **Other architectures**: Interpreted engines only (no JIT)
+| Platform | JIT Support | SIMD Support |
+|----------|-------------|--------------|
+| Linux x86-64 | ✓ | ✓ (AVX2) |
+| Linux ARM64 | ✓ | ✗ |
+| macOS x86-64 | ✓ | ✓ (AVX2) |
+| macOS ARM64 (Apple Silicon) | ✓ | ✗ |
+| Windows x86-64 | ✓ | ✓ (AVX2) |
+| Other | ✗ | ✗ |
 
 ### Feature Compatibility
 

--- a/src/dfa/eager/interpreter/dfa.rs
+++ b/src/dfa/eager/interpreter/dfa.rs
@@ -256,7 +256,7 @@ impl EagerDfa {
                     return Some((0, end));
                 }
                 for (i, &byte) in input.iter().enumerate() {
-                    if byte == b'\n' && i + 1 <= input.len() {
+                    if byte == b'\n' && i < input.len() {
                         if let Some(end) = self.find_at(input, i + 1) {
                             return Some((i + 1, end));
                         }

--- a/src/dfa/lazy/interpreter/dfa.rs
+++ b/src/dfa/lazy/interpreter/dfa.rs
@@ -146,11 +146,7 @@ impl LazyDfa {
         };
 
         let pos_ctx = if self.ctx.has_anchors {
-            if self.ctx.has_multiline_anchors && byte == b'\n' {
-                Some(PositionContext::middle())
-            } else {
-                Some(PositionContext::middle())
-            }
+            Some(PositionContext::middle())
         } else {
             None
         };
@@ -208,7 +204,7 @@ impl LazyDfa {
         let next_id = get_or_create_state_with_class(&mut self.ctx, next_closure, curr_class);
 
         let next_idx = state_index(next_id);
-        let is_match = self.ctx.states.get(next_idx).map_or(false, |s| s.is_match);
+        let is_match = self.ctx.states.get(next_idx).is_some_and(|s| s.is_match);
 
         let cache_idx = (state + byte as u32) as usize;
         if cache_idx < self.ctx.transitions.len() {
@@ -332,15 +328,13 @@ impl LazyDfa {
                 result[byte as usize] = Some(next_id);
 
                 let next_idx = state_index(next_id);
-                let is_match = self.ctx.states.get(next_idx).map_or(false, |s| s.is_match);
+                let is_match = self.ctx.states.get(next_idx).is_some_and(|s| s.is_match);
                 let cache_idx = (state + byte as u32) as usize;
                 if cache_idx < self.ctx.transitions.len() {
                     self.ctx.transitions[cache_idx] = tag_state(next_id, is_match);
                 }
-            } else {
-                if cache_idx < self.ctx.transitions.len() {
-                    self.ctx.transitions[cache_idx] = DEAD_STATE;
-                }
+            } else if cache_idx < self.ctx.transitions.len() {
+                self.ctx.transitions[cache_idx] = DEAD_STATE;
             }
         }
     }
@@ -405,7 +399,7 @@ impl LazyDfa {
                     return Some((0, end));
                 }
                 for (i, &byte) in input.iter().enumerate() {
-                    if byte == b'\n' && i + 1 <= input.len() {
+                    if byte == b'\n' && i < input.len() {
                         if let Some(end) = self.find_at(input, i + 1) {
                             return Some((i + 1, end));
                         }
@@ -467,11 +461,7 @@ impl LazyDfa {
             let mut start_set = BTreeSet::new();
             start_set.insert(self.ctx.nfa.start);
 
-            let is_at_boundary = if self.ctx.has_word_boundary {
-                None
-            } else {
-                None
-            };
+            let is_at_boundary: Option<bool> = None;
 
             let start_closure = epsilon_closure_with_context(
                 &self.ctx.nfa,
@@ -755,7 +745,7 @@ impl LazyDfa {
             if let Some(nfa_state) = self.ctx.nfa.get(nfa_id) {
                 if nfa_state.is_match {
                     // Check if this match state has any pending END anchor
-                    let has_end_anchor = nfa_state.instruction.as_ref().map_or(false, |instr| {
+                    let has_end_anchor = nfa_state.instruction.as_ref().is_some_and(|instr| {
                         matches!(instr, NfaInstruction::EndOfLine | NfaInstruction::EndOfText)
                     });
                     if !has_end_anchor {
@@ -778,6 +768,7 @@ impl LazyDfa {
     /// For example, in pattern `(?m)^A|B$`:
     /// - Branch 1 reaches match through ^A (no end anchor)
     /// - Branch 2 reaches match through B$ (EndOfLine)
+    ///
     /// After matching, the DFA state may include states from both branches.
     /// If EndOfLine was filtered out during epsilon closure (because we're not at EOL),
     /// we shouldn't require it - branch 1's path is still valid.
@@ -786,9 +777,10 @@ impl LazyDfa {
         F: Fn(&NfaInstruction) -> bool,
     {
         nfa_states.iter().any(|&nfa_id| {
-            self.ctx.nfa.get(nfa_id).map_or(false, |nfa_state| {
-                nfa_state.instruction.as_ref().map_or(false, &pred)
-            })
+            self.ctx
+                .nfa
+                .get(nfa_id)
+                .is_some_and(|nfa_state| nfa_state.instruction.as_ref().is_some_and(&pred))
         })
     }
 

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -58,6 +58,7 @@ impl std::fmt::Debug for CompiledRegex {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum CompiledInner {
     PikeVm(PikeVm),
     ShiftOr(ShiftOr),
@@ -212,11 +213,12 @@ impl CompiledRegex {
 
                 // Find the first word boundary in the lookback window
                 for i in (start_pos..inner_pos).rev() {
-                    if i == 0 || !is_word_byte(input[i - 1]) {
-                        if i < input.len() && is_word_byte(input[i]) {
-                            candidate = i;
-                            break;
-                        }
+                    if (i == 0 || !is_word_byte(input[i - 1]))
+                        && i < input.len()
+                        && is_word_byte(input[i])
+                    {
+                        candidate = i;
+                        break;
                     }
                 }
 
@@ -313,11 +315,9 @@ impl CompiledRegex {
                 // Use the optimized context-based method
                 vm.captures_from_start_with_context(&input[start..], ctx)
                     .map(|mut caps| {
-                        for slot in &mut caps {
-                            if let Some((s, e)) = slot {
-                                *s += start;
-                                *e += start;
-                            }
+                        for (s, e) in caps.iter_mut().flatten() {
+                            *s += start;
+                            *e += start;
                         }
                         caps
                     })
@@ -346,11 +346,9 @@ impl CompiledRegex {
                 vm.captures_from_start_with_context(&input[start..], ctx)
                     .map(|mut caps| {
                         // Adjust capture positions to absolute offsets
-                        for slot in &mut caps {
-                            if let Some((s, e)) = slot {
-                                *s += start;
-                                *e += start;
-                            }
+                        for (s, e) in caps.iter_mut().flatten() {
+                            *s += start;
+                            *e += start;
                         }
                         caps
                     })
@@ -372,11 +370,9 @@ impl CompiledRegex {
                 let ctx = ctx_ref.as_mut()?;
                 vm.captures_from_start_with_context(&input[start..], ctx)
                     .map(|mut caps| {
-                        for slot in &mut caps {
-                            if let Some((s, e)) = slot {
-                                *s += start;
-                                *e += start;
-                            }
+                        for (s, e) in caps.iter_mut().flatten() {
+                            *s += start;
+                            *e += start;
                         }
                         caps
                     })

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -788,7 +788,10 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
                     capture_vm: RwLock::new(None),
                     capture_ctx: RwLock::new(None),
                     backtracking_vm: None,
-                    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
+                    #[cfg(all(
+                        feature = "jit",
+                        any(target_arch = "x86_64", target_arch = "aarch64")
+                    ))]
                     backtracking_jit: None,
                 });
             }

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -15,7 +15,7 @@ use crate::vm::{
     BacktrackingVm, CodepointClassMatcher, PikeVm, PikeVmContext, ShiftOr, ShiftOrWide,
 };
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 use crate::jit;
 
 use super::{select_engine, select_engine_from_hir, EngineType};
@@ -45,7 +45,7 @@ pub struct CompiledRegex {
     /// BacktrackingJit for fast single-pass capture extraction in JIT mode.
     /// Used by JitShiftOr when pattern has captures.
     /// This is the JIT equivalent of backtracking_vm.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     backtracking_jit: Option<jit::BacktrackingJit>,
 }
 
@@ -77,19 +77,19 @@ enum CompiledInner {
     /// Uses liveness analysis for efficient single-pass capture extraction.
     /// Always available (no JIT required).
     TaggedNfaInterp(TaggedNfaEngine),
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     Jit(jit::CompiledRegex),
     /// Tagged NFA JIT engine for patterns with lookaround or non-greedy.
     /// Uses liveness analysis for efficient single-pass capture extraction.
     /// JIT compiles the NFA to native code for better performance.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     TaggedNfaJit(jit::TaggedNfaJit),
     /// Backtracking JIT engine for patterns with backreferences.
     /// Uses PCRE-style backtracking for fast backreference matching.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     Backtracking(jit::BacktrackingJit),
     /// JIT-compiled Shift-Or engine for word boundary patterns.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     JitShiftOr(jit::JitShiftOr),
 }
 
@@ -105,13 +105,13 @@ impl CompiledRegex {
             CompiledInner::CodepointClass(_) => "CodepointClass",
             CompiledInner::BacktrackingVm(_) => "BacktrackingVm",
             CompiledInner::TaggedNfaInterp(_) => "TaggedNfa",
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Jit(_) => "Jit",
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::TaggedNfaJit(_) => "TaggedNfaJit",
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Backtracking(_) => "BacktrackingJit",
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::JitShiftOr(_) => "JitShiftOr",
         }
     }
@@ -158,13 +158,13 @@ impl CompiledRegex {
             CompiledInner::CodepointClass(matcher) => matcher.is_match(input),
             CompiledInner::BacktrackingVm(vm) => vm.find(input).is_some(),
             CompiledInner::TaggedNfaInterp(engine) => engine.is_match(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Jit(jit) => jit.is_match(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::TaggedNfaJit(engine) => engine.is_match(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Backtracking(jit) => jit.is_match(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::JitShiftOr(jit) => jit.find(input).is_some(),
         }
     }
@@ -253,13 +253,13 @@ impl CompiledRegex {
             CompiledInner::CodepointClass(matcher) => matcher.find(input),
             CompiledInner::BacktrackingVm(vm) => vm.find(input),
             CompiledInner::TaggedNfaInterp(engine) => engine.find(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Jit(jit) => jit.find(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::TaggedNfaJit(engine) => engine.find(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Backtracking(jit) => jit.find(input),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::JitShiftOr(jit) => jit.find(input),
         }
     }
@@ -283,17 +283,17 @@ impl CompiledRegex {
                 // TaggedNfa interpreter does single-pass capture extraction
                 engine.captures(input)
             }
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::TaggedNfaJit(engine) => {
                 // TaggedNfa JIT does single-pass capture extraction
                 engine.captures(input)
             }
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Backtracking(jit) => {
                 // Backtracking JIT does single-pass capture extraction
                 jit.captures(input)
             }
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Jit(_) => {
                 // Fast path: if we have BacktrackingVm, use it for single-pass capture extraction
                 if let Some(ref backtracking_vm) = self.backtracking_vm {
@@ -355,7 +355,7 @@ impl CompiledRegex {
                         caps
                     })
             }
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::JitShiftOr(_) => {
                 // Use BacktrackingJit for capture extraction if available
                 // This is the JIT equivalent of BacktrackingVm used by non-JIT ShiftOr
@@ -417,13 +417,13 @@ impl CompiledRegex {
             }
             CompiledInner::BacktrackingVm(vm) => vm.find_at(input, pos),
             CompiledInner::TaggedNfaInterp(engine) => engine.find_at(input, pos),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Jit(jit) => jit.find_at(input, pos),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::TaggedNfaJit(engine) => engine.find_at(input, pos),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::Backtracking(jit) => jit.find_at(input, pos),
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             CompiledInner::JitShiftOr(jit) => jit.try_match_at(input, pos),
         }
     }
@@ -487,7 +487,7 @@ pub fn compile(nfa: Nfa) -> Result<CompiledRegex> {
         capture_vm: RwLock::new(None),
         capture_ctx: RwLock::new(None),
         backtracking_vm: None,
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         backtracking_jit: None,
     })
 }
@@ -508,7 +508,7 @@ pub fn compile_from_hir(hir: &Hir) -> Result<CompiledRegex> {
             capture_vm: RwLock::new(None),
             capture_ctx: RwLock::new(None),
             backtracking_vm: None,
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             backtracking_jit: None,
         });
     }
@@ -529,7 +529,7 @@ pub fn compile_from_hir(hir: &Hir) -> Result<CompiledRegex> {
             capture_vm: RwLock::new(None),
             capture_ctx: RwLock::new(None),
             backtracking_vm: None,
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             backtracking_jit: None,
         });
     }
@@ -663,7 +663,7 @@ pub fn compile_from_hir(hir: &Hir) -> Result<CompiledRegex> {
         capture_vm: RwLock::new(None),
         capture_ctx: RwLock::new(None),
         backtracking_vm,
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         backtracking_jit: None,
     })
 }
@@ -686,7 +686,7 @@ pub fn compile_with_pikevm(hir: &Hir) -> Result<CompiledRegex> {
         capture_vm: RwLock::new(None),
         capture_ctx: RwLock::new(None),
         backtracking_vm: None,
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         backtracking_jit: None,
     })
 }
@@ -713,7 +713,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
             capture_vm: RwLock::new(None),
             capture_ctx: RwLock::new(None),
             backtracking_vm: None,
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             backtracking_jit: None,
         });
     }
@@ -721,7 +721,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
     // 1. Complex Unicode patterns with large unicode classes → TaggedNfa JIT
     // These patterns use CodepointClass instructions which DFA cannot handle.
     // Route them to TaggedNfa JIT which supports CodepointClass.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     if hir.props.has_large_unicode_class {
         let literals = extract_literals(hir);
         let prefilter = Prefilter::from_literals(&literals);
@@ -757,7 +757,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
     }
 
     // Non-JIT: Large unicode classes go to TaggedNfa interpreter
-    #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+    #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
     if hir.props.has_large_unicode_class {
         let literals = extract_literals(hir);
         let prefilter = Prefilter::from_literals(&literals);
@@ -775,7 +775,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
 
     // 2. Patterns with backreferences → Backtracking JIT (only way to handle backrefs)
     // Backtracking JIT is required for backreferences since DFA cannot handle them.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     if hir.props.has_backrefs && !hir.props.has_lookaround {
         let literals = extract_literals(hir);
         let prefilter = Prefilter::from_literals(&literals);
@@ -788,7 +788,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
                     capture_vm: RwLock::new(None),
                     capture_ctx: RwLock::new(None),
                     backtracking_vm: None,
-                    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+                    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
                     backtracking_jit: None,
                 });
             }
@@ -808,7 +808,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
     // because DFA JIT is much faster. DFA JIT handles captures via two-pass:
     // 1. Fast DFA JIT for find()
     // 2. PikeVM on matched substring for captures() only when needed
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     if hir.props.has_lookaround || hir.props.has_non_greedy {
         let literals = extract_literals(hir);
         let prefilter = Prefilter::from_literals(&literals);
@@ -849,7 +849,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
 
     // Fall back to TaggedNfa interpreter when JIT feature is not available
     // Note: TaggedNfa interpreter is now always available (faster than PikeVm for lookaround)
-    #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+    #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
     if hir.props.has_lookaround || hir.props.has_non_greedy {
         let literals = extract_literals(hir);
         let prefilter = Prefilter::from_literals(&literals);
@@ -866,7 +866,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
     }
 
     // For backrefs without JIT, fall back to PikeVM
-    #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+    #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
     if hir.props.has_backrefs {
         return compile_with_pikevm(hir);
     }
@@ -875,7 +875,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
     // ShiftOr's bit-parallel algorithm is faster than DFA JIT for patterns with
     // many alternations and no common prefix (no effective prefilter).
     // DFA JIT excels when there's a good prefilter to skip non-matching positions.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     {
         use crate::vm::is_shift_or_compatible;
         let literals = extract_literals(hir);
@@ -928,7 +928,7 @@ pub fn compile_with_jit(hir: &Hir) -> Result<CompiledRegex> {
 
     // 4. Simple patterns with effective prefilter → DFA JIT
     // DFA JIT benefits from prefilter to quickly skip non-matching positions.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     {
         let literals = extract_literals(hir);
         let prefilter = Prefilter::from_literals(&literals);
@@ -1115,7 +1115,7 @@ mod tests {
     // TaggedNfa integration tests (backrefs, lookaround, non-greedy)
     // These patterns trigger the TaggedNfaEngine path when JIT is enabled
 
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     mod tagged_nfa_integration {
         use super::*;
         use crate::engine::compile_with_jit;

--- a/src/engine/selector.rs
+++ b/src/engine/selector.rs
@@ -143,8 +143,8 @@ impl Capabilities {
 
     #[cfg(feature = "jit")]
     fn detect_jit() -> bool {
-        // JIT is available on x86-64 Linux/macOS/Windows
-        cfg!(target_arch = "x86_64")
+        // JIT is available on x86-64 and aarch64 (Linux/macOS/Windows)
+        cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
     }
 }
 

--- a/src/hir/builder.rs
+++ b/src/hir/builder.rs
@@ -599,6 +599,7 @@ impl HirTranslator {
 
     /// Builds a trie-based HIR expression for UTF-8 sequences.
     /// This shares common prefixes to minimize NFA states.
+    #[allow(clippy::only_used_in_recursion)]
     fn build_utf8_trie(&self, sequences: &[Utf8Sequence]) -> HirExpr {
         if sequences.is_empty() {
             return HirExpr::Empty;

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -71,7 +71,7 @@ pub struct CodepointClass {
     /// Whether this class is negated.
     pub negated: bool,
     /// Precomputed ASCII bitmap for fast lookup of codepoints 0-127.
-    /// ascii_bitmap[0] covers bits 0-63, ascii_bitmap[1] covers bits 64-127.
+    /// `ascii_bitmap[0]` covers bits 0-63, `ascii_bitmap[1]` covers bits 64-127.
     /// A set bit means the codepoint is IN the class (before negation is applied).
     pub ascii_bitmap: [u64; 2],
 }

--- a/src/hir/prefix_opt.rs
+++ b/src/hir/prefix_opt.rs
@@ -50,7 +50,7 @@ impl TrieNode {
     fn insert(&mut self, bytes: &[u8], capture_index: Option<u32>, capture_name: Option<String>) {
         let mut node = self;
         for &byte in bytes {
-            node = node.children.entry(byte).or_insert_with(TrieNode::new);
+            node = node.children.entry(byte).or_default();
         }
         node.is_terminal = true;
         node.capture_index = capture_index;
@@ -61,11 +61,7 @@ impl TrieNode {
     fn to_hir(&self) -> HirExpr {
         // If this is a terminal with no children, return empty
         if self.children.is_empty() {
-            return if self.is_terminal {
-                HirExpr::Empty
-            } else {
-                HirExpr::Empty
-            };
+            return HirExpr::Empty;
         }
 
         // Collect all children

--- a/src/jit/aarch64.rs
+++ b/src/jit/aarch64.rs
@@ -1,0 +1,850 @@
+//! AArch64 (ARM64) code generation using dynasm.
+//!
+//! This module emits native ARM64 assembly code for DFA state machines.
+//! All code is W^X compliant and optimized for performance.
+//!
+//! # Platform Support
+//!
+//! Uses AAPCS64 calling convention on all ARM64 platforms:
+//! - **Arguments**: X0-X7
+//! - **Return value**: X0
+//! - **Callee-saved**: X19-X28, SP
+//! - **Link register**: X30
+//! - **Frame pointer**: X29
+
+use crate::dfa::DfaStateId;
+use crate::error::{Error, ErrorKind, Result};
+use crate::jit::codegen_aarch64::{MaterializedDfa, MaterializedState};
+use dynasm::dynasm;
+use dynasmrt::{
+    aarch64::Assembler, AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, ExecutableBuffer,
+};
+
+/// Compiles a materialized DFA to ARM64 machine code.
+///
+/// # Calling Convention (AAPCS64)
+///
+/// The function accepts two arguments:
+/// - X0: input pointer (const uint8_t*)
+/// - X1: length (size_t)
+///
+/// # Internal Register Usage
+/// - `x19` = current position in input (mutable, incremented during execution)
+/// - `x20` = input base pointer (immutable)
+/// - `x21` = input end pointer (base + len, immutable)
+/// - `x22` = last match position, initialized to -1 (for longest-match semantics)
+/// - `x23` = search start position (for unanchored search)
+/// - `x24` = prev_char_class (0 = NonWord, 1 = Word) for word boundary patterns
+/// - `x9-x15` = scratch registers
+///
+/// # Function Signature
+/// ```c
+/// int64_t match_fn(const uint8_t* input, size_t len);
+/// ```
+///
+/// Returns:
+/// - >= 0: Match found, packed as (start << 32 | end)
+/// - -1: No match
+pub fn compile_states(
+    dfa: &MaterializedDfa,
+) -> Result<(ExecutableBuffer, AssemblyOffset, Option<AssemblyOffset>)> {
+    let mut asm = Assembler::new().map_err(|e| {
+        Error::new(
+            ErrorKind::Jit(format!("Failed to create assembler: {:?}", e)),
+            "",
+        )
+    })?;
+
+    // Create state label lookup using Vec for O(1) lookup
+    let max_state_id = dfa.states.iter().map(|s| s.id).max().unwrap_or(0) as usize;
+    let mut state_labels: Vec<Option<DynamicLabel>> = vec![None; max_state_id + 1];
+    for state in &dfa.states {
+        state_labels[state.id as usize] = Some(asm.new_dynamic_label());
+    }
+    let dead_label = asm.new_dynamic_label();
+    let no_match_label = asm.new_dynamic_label();
+
+    // For unanchored patterns, create a restart label for the internal search loop
+    let restart_label = if !dfa.has_start_anchor {
+        Some(asm.new_dynamic_label())
+    } else {
+        None
+    };
+
+    // For word boundary patterns, create a dispatch label
+    let dispatch_label = if dfa.has_word_boundary && dfa.start_word.is_some() {
+        Some(asm.new_dynamic_label())
+    } else {
+        None
+    };
+
+    // Emit prologue for NonWord prev_class (primary entry point)
+    let entry_point = asm.offset();
+    emit_prologue(
+        &mut asm,
+        dfa.start,
+        &state_labels,
+        restart_label,
+        dispatch_label,
+        dfa.has_word_boundary,
+        true,
+    )?;
+
+    // Emit prologue for Word prev_class (secondary entry point, if needed)
+    let entry_point_word = if let Some(start_word) = dfa.start_word {
+        let offset = asm.offset();
+        emit_prologue(
+            &mut asm,
+            start_word,
+            &state_labels,
+            restart_label,
+            dispatch_label,
+            dfa.has_word_boundary,
+            false,
+        )?;
+        Some(offset)
+    } else {
+        None
+    };
+
+    // Emit dispatch block for word boundary patterns
+    if let (Some(dispatch), Some(start_word)) = (dispatch_label, dfa.start_word) {
+        emit_dispatch(&mut asm, dispatch, dfa.start, start_word, &state_labels)?;
+    }
+
+    // Emit code for each DFA state
+    for state in &dfa.states {
+        emit_state(&mut asm, state, &state_labels, dead_label, no_match_label)?;
+    }
+
+    // Emit dead state
+    emit_dead_state(
+        &mut asm,
+        dead_label,
+        no_match_label,
+        restart_label,
+        dispatch_label,
+        dfa.has_word_boundary,
+    )?;
+
+    // Emit no-match epilogue
+    emit_no_match(&mut asm, no_match_label, dfa.has_word_boundary)?;
+
+    // Finalize and get executable buffer
+    let code = asm.finalize().map_err(|_| {
+        Error::new(
+            ErrorKind::Jit("Failed to finalize assembly".to_string()),
+            "",
+        )
+    })?;
+
+    Ok((code, entry_point, entry_point_word))
+}
+
+/// Emits the function prologue.
+///
+/// Register allocation:
+/// - x19 = current position (starts at 0)
+/// - x20 = input base pointer
+/// - x21 = input end pointer
+/// - x22 = last match position (-1)
+/// - x23 = search start position (0)
+/// - x24 = prev_char_class (for word boundaries)
+fn emit_prologue(
+    asm: &mut Assembler,
+    start_state: DfaStateId,
+    state_labels: &[Option<DynamicLabel>],
+    restart_label: Option<DynamicLabel>,
+    dispatch_label: Option<DynamicLabel>,
+    has_word_boundary: bool,
+    emit_restart_label: bool,
+) -> Result<()> {
+    let start_label = state_labels
+        .get(start_state as usize)
+        .and_then(|opt| opt.as_ref())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::Jit("Start state label not found".to_string()),
+                "",
+            )
+        })?;
+
+    // Save callee-saved registers and set up frame
+    dynasm!(asm
+        ; .arch aarch64
+        // Save frame pointer and link register
+        ; stp x29, x30, [sp, #-16]!
+        ; mov x29, sp
+        // Save callee-saved registers we'll use
+        ; stp x19, x20, [sp, #-16]!
+        ; stp x21, x22, [sp, #-16]!
+        ; stp x23, x24, [sp, #-16]!
+    );
+
+    // AAPCS64: Arguments in X0, X1
+    // X0 = input ptr, X1 = len
+    dynasm!(asm
+        ; mov x20, x0              // x20 = input base
+        ; add x21, x0, x1          // x21 = input end (base + len)
+        ; mov x19, #0              // x19 = position = 0
+        ; movn x22, 0              // x22 = last match = -1
+        ; mov x23, #0              // x23 = search start = 0
+    );
+
+    // For word boundary patterns, initialize x24 = prev_char_class
+    if has_word_boundary {
+        dynasm!(asm
+            ; mov x24, #0             // x24 = 0 (NonWord at start)
+        );
+    }
+
+    // Emit restart label if this is the primary entry point
+    if let Some(restart) = restart_label {
+        if emit_restart_label {
+            dynasm!(asm
+                ; =>restart
+            );
+        }
+    }
+
+    // For word boundary secondary entry, set x24 = 1 (Word)
+    if dispatch_label.is_some() && !emit_restart_label {
+        dynasm!(asm
+            ; mov x24, #1             // x24 = 1 (Word)
+        );
+    }
+
+    // Jump to start state
+    dynasm!(asm
+        ; b =>*start_label
+    );
+
+    Ok(())
+}
+
+/// Emits the dispatch block for word boundary patterns.
+fn emit_dispatch(
+    asm: &mut Assembler,
+    dispatch_label: DynamicLabel,
+    start: DfaStateId,
+    start_word: DfaStateId,
+    state_labels: &[Option<DynamicLabel>],
+) -> Result<()> {
+    let start_label = state_labels
+        .get(start as usize)
+        .and_then(|opt| opt.as_ref())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::Jit("Start state label not found".to_string()),
+                "",
+            )
+        })?;
+    let start_word_label = state_labels
+        .get(start_word as usize)
+        .and_then(|opt| opt.as_ref())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::Jit("Start word state label not found".to_string()),
+                "",
+            )
+        })?;
+
+    dynasm!(asm
+        ; .align 4
+        ; =>dispatch_label
+        // Check x24: 0 = NonWord, 1 = Word
+        ; cbnz x24, =>*start_word_label
+        ; b =>*start_label
+    );
+
+    Ok(())
+}
+
+/// Analyzes if a state has a self-loop pattern suitable for fast-forward optimization.
+fn analyze_self_loop(
+    state: &MaterializedState,
+) -> Option<(Vec<(u8, u8)>, Vec<(u8, u8, DfaStateId)>)> {
+    let mut self_loop_bytes = Vec::new();
+    let mut other_transitions = Vec::new();
+
+    for byte in 0..=255u8 {
+        if let Some(target) = state.transitions[byte as usize] {
+            if target == state.id {
+                self_loop_bytes.push(byte);
+            } else {
+                other_transitions.push((byte, target));
+            }
+        }
+    }
+
+    if self_loop_bytes.len() < 3 {
+        return None;
+    }
+
+    // Convert to contiguous ranges
+    let mut self_loop_ranges = Vec::new();
+    if !self_loop_bytes.is_empty() {
+        let mut start = self_loop_bytes[0];
+        let mut end = self_loop_bytes[0];
+
+        for &byte in &self_loop_bytes[1..] {
+            if byte == end + 1 {
+                end = byte;
+            } else {
+                self_loop_ranges.push((start, end));
+                start = byte;
+                end = byte;
+            }
+        }
+        self_loop_ranges.push((start, end));
+    }
+
+    // Convert other transitions to ranges
+    let mut other_ranges = Vec::new();
+    if !other_transitions.is_empty() {
+        let mut sorted = other_transitions.clone();
+        sorted.sort_by_key(|(b, _)| *b);
+
+        let mut start = sorted[0].0;
+        let mut end = sorted[0].0;
+        let mut target = sorted[0].1;
+
+        for &(byte, t) in &sorted[1..] {
+            if byte == end + 1 && t == target {
+                end = byte;
+            } else {
+                other_ranges.push((start, end, target));
+                start = byte;
+                end = byte;
+                target = t;
+            }
+        }
+        other_ranges.push((start, end, target));
+    }
+
+    Some((self_loop_ranges, other_ranges))
+}
+
+/// Emits code for a single DFA state.
+fn emit_state(
+    asm: &mut Assembler,
+    state: &MaterializedState,
+    state_labels: &[Option<DynamicLabel>],
+    dead_label: DynamicLabel,
+    no_match_label: DynamicLabel,
+) -> Result<()> {
+    let state_label = state_labels
+        .get(state.id as usize)
+        .and_then(|opt| opt.as_ref())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::Jit(format!("Label for state {} not found", state.id)),
+                "",
+            )
+        })?;
+
+    let match_return = asm.new_dynamic_label();
+
+    // Align for optimal instruction fetch
+    dynasm!(asm
+        ; .align 4
+        ; =>*state_label
+    );
+
+    // Check if input is exhausted
+    // x19 = position, x20 = base, x21 = end
+    if state.is_match {
+        // Save current position as last match
+        dynasm!(asm
+            ; mov x22, x19
+        );
+        // Check if exhausted
+        dynasm!(asm
+            ; add x9, x20, x19         // x9 = base + pos
+            ; cmp x9, x21
+            ; b.hs =>match_return
+        );
+    } else {
+        dynasm!(asm
+            ; add x9, x20, x19
+            ; cmp x9, x21
+            ; b.hs =>no_match_label
+        );
+    }
+
+    // Check for self-loop optimization
+    if let Some((self_loop_ranges, other_transitions)) = analyze_self_loop(state) {
+        emit_fast_forward_loop(
+            asm,
+            state,
+            &self_loop_ranges,
+            &other_transitions,
+            state_labels,
+            dead_label,
+            no_match_label,
+        )?;
+    } else {
+        // Load next byte and increment position
+        dynasm!(asm
+            ; ldrb w9, [x20, x19]      // w9 = input[pos]
+            ; add x19, x19, #1         // pos++
+        );
+
+        // Emit transitions
+        if state.should_use_jump_table() {
+            emit_dense_transitions(asm, state, state_labels, dead_label)?;
+        } else {
+            emit_sparse_transitions(asm, state, state_labels, dead_label)?;
+        }
+    }
+
+    // Match return label
+    if state.is_match {
+        dynasm!(asm
+            ; =>match_return
+            ; b =>no_match_label
+        );
+    }
+
+    Ok(())
+}
+
+/// Builds a 256-bit bitmap for the self-loop character class.
+fn build_self_loop_bitmap(self_loop_ranges: &[(u8, u8)]) -> [u8; 32] {
+    let mut bitmap = [0u8; 32];
+    for &(start, end) in self_loop_ranges {
+        for byte in start..=end {
+            bitmap[byte as usize / 8] |= 1 << (byte % 8);
+        }
+    }
+    bitmap
+}
+
+/// Emits a fast-forward loop for states with self-loops.
+fn emit_fast_forward_loop(
+    asm: &mut Assembler,
+    state: &MaterializedState,
+    self_loop_ranges: &[(u8, u8)],
+    other_transitions: &[(u8, u8, DfaStateId)],
+    state_labels: &[Option<DynamicLabel>],
+    dead_label: DynamicLabel,
+    no_match_label: DynamicLabel,
+) -> Result<()> {
+    let fast_forward_loop = asm.new_dynamic_label();
+    let exhausted = asm.new_dynamic_label();
+    let check_other = asm.new_dynamic_label();
+    let consume_byte = asm.new_dynamic_label();
+
+    // Use bitmap for 3+ ranges, otherwise use range checks
+    let use_bitmap = self_loop_ranges.len() >= 3;
+
+    if use_bitmap {
+        let bitmap = build_self_loop_bitmap(self_loop_ranges);
+        let bitmap_label = asm.new_dynamic_label();
+        let start_label = asm.new_dynamic_label();
+
+        // Embed bitmap data
+        dynasm!(asm
+            ; b =>start_label
+            ; .align 8
+            ; =>bitmap_label
+            ; .bytes bitmap.as_slice()
+            ; =>start_label
+        );
+
+        // Load bitmap address into x10
+        dynasm!(asm
+            ; adr x10, =>bitmap_label
+        );
+
+        // Fast-forward loop with bitmap
+        dynasm!(asm
+            ; =>fast_forward_loop
+            // Check bounds
+            ; add x9, x20, x19
+            ; cmp x9, x21
+            ; b.hs =>exhausted
+            // Load byte
+            ; ldrb w9, [x20, x19]
+            // Bitmap lookup: bitmap[byte / 8] & (1 << (byte % 8))
+            ; lsr w11, w9, #3          // w11 = byte / 8
+            ; and w12, w9, #7          // w12 = byte % 8
+            ; ldrb w13, [x10, x11]     // w13 = bitmap[byte / 8]
+            ; mov w14, #1
+            ; lsl w14, w14, w12        // w14 = 1 << (byte % 8)
+            ; tst w13, w14
+            ; b.eq =>check_other       // Not in class
+            // Consume byte
+            ; add x19, x19, #1
+        );
+
+        if state.is_match {
+            dynasm!(asm
+                ; mov x22, x19
+            );
+        }
+
+        dynasm!(asm
+            ; b =>fast_forward_loop
+        );
+    } else {
+        // Range-based fast forward
+        dynasm!(asm
+            ; =>fast_forward_loop
+            // Check bounds
+            ; add x9, x20, x19
+            ; cmp x9, x21
+            ; b.hs =>exhausted
+            // Load byte
+            ; ldrb w9, [x20, x19]
+        );
+
+        // Check if byte is in self-loop ranges
+        for (i, &(start, end)) in self_loop_ranges.iter().enumerate() {
+            if start == end {
+                dynasm!(asm
+                    ; cmp w9, #start as u32
+                    ; b.eq =>consume_byte
+                );
+            } else {
+                let next_range = asm.new_dynamic_label();
+                dynasm!(asm
+                    ; cmp w9, #start as u32
+                    ; b.lo =>next_range
+                    ; cmp w9, #end as u32
+                    ; b.ls =>consume_byte
+                    ; =>next_range
+                );
+            }
+
+            if i == self_loop_ranges.len() - 1 {
+                dynasm!(asm
+                    ; b =>check_other
+                );
+            }
+        }
+
+        // Consume byte
+        dynasm!(asm
+            ; =>consume_byte
+            ; add x19, x19, #1
+        );
+
+        if state.is_match {
+            dynasm!(asm
+                ; mov x22, x19
+            );
+        }
+
+        dynasm!(asm
+            ; b =>fast_forward_loop
+        );
+    }
+
+    // Exhausted - jump to no_match which will check x22
+    dynasm!(asm
+        ; =>exhausted
+        ; b =>no_match_label
+    );
+
+    // Check other transitions
+    dynasm!(asm
+        ; =>check_other
+    );
+
+    if !other_transitions.is_empty() {
+        // Reload byte and consume
+        dynasm!(asm
+            ; ldrb w9, [x20, x19]
+            ; add x19, x19, #1
+        );
+
+        for &(start, end, target) in other_transitions {
+            let target_label = state_labels
+                .get(target as usize)
+                .and_then(|opt| opt.as_ref())
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::Jit(format!("Label for state {} not found", target)),
+                        "",
+                    )
+                })?;
+
+            if start == end {
+                dynasm!(asm
+                    ; cmp w9, #start as u32
+                    ; b.eq =>*target_label
+                );
+            } else {
+                let next = asm.new_dynamic_label();
+                dynasm!(asm
+                    ; cmp w9, #start as u32
+                    ; b.lo =>next
+                    ; cmp w9, #end as u32
+                    ; b.ls =>*target_label
+                    ; =>next
+                );
+            }
+        }
+    }
+
+    // No transition matched
+    dynasm!(asm
+        ; b =>dead_label
+    );
+
+    Ok(())
+}
+
+/// Emits sparse transition code using linear compare chains.
+fn emit_sparse_transitions(
+    asm: &mut Assembler,
+    state: &MaterializedState,
+    state_labels: &[Option<DynamicLabel>],
+    dead_label: DynamicLabel,
+) -> Result<()> {
+    let ranges = compute_byte_ranges(state);
+
+    for (start, end, target) in ranges {
+        let target_label = state_labels
+            .get(target as usize)
+            .and_then(|opt| opt.as_ref())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::Jit(format!("Label for state {} not found", target)),
+                    "",
+                )
+            })?;
+
+        if start == end {
+            dynasm!(asm
+                ; cmp w9, #start as u32
+                ; b.eq =>*target_label
+            );
+        } else {
+            let next_check = asm.new_dynamic_label();
+            dynasm!(asm
+                ; cmp w9, #start as u32
+                ; b.lo =>next_check
+                ; cmp w9, #end as u32
+                ; b.ls =>*target_label
+                ; =>next_check
+            );
+        }
+    }
+
+    // No transition matched
+    dynasm!(asm
+        ; b =>dead_label
+    );
+
+    Ok(())
+}
+
+/// Emits dense transition code using range checks.
+fn emit_dense_transitions(
+    asm: &mut Assembler,
+    state: &MaterializedState,
+    state_labels: &[Option<DynamicLabel>],
+    dead_label: DynamicLabel,
+) -> Result<()> {
+    let ranges = compute_byte_ranges(state);
+
+    for (start, end, target) in ranges {
+        let target_label = state_labels
+            .get(target as usize)
+            .and_then(|opt| opt.as_ref())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::Jit(format!("Label for state {} not found", target)),
+                    "",
+                )
+            })?;
+
+        if start == end {
+            dynasm!(asm
+                ; cmp w9, #start as u32
+                ; b.eq =>*target_label
+            );
+        } else {
+            let next = asm.new_dynamic_label();
+            dynasm!(asm
+                ; cmp w9, #start as u32
+                ; b.lo =>next
+                ; cmp w9, #end as u32
+                ; b.ls =>*target_label
+                ; =>next
+            );
+        }
+    }
+
+    dynasm!(asm
+        ; b =>dead_label
+    );
+
+    Ok(())
+}
+
+/// Computes byte ranges for efficient transitions.
+fn compute_byte_ranges(state: &MaterializedState) -> Vec<(u8, u8, DfaStateId)> {
+    let mut ranges = Vec::new();
+    let mut current_target: Option<DfaStateId> = None;
+    let mut range_start = 0u8;
+
+    for byte in 0..=255u8 {
+        let target = state.transitions[byte as usize];
+
+        match (current_target, target) {
+            (None, Some(t)) => {
+                current_target = Some(t);
+                range_start = byte;
+            }
+            (Some(curr), Some(t)) if curr == t => {}
+            (Some(curr), _) => {
+                ranges.push((range_start, byte - 1, curr));
+                current_target = target;
+                range_start = byte;
+            }
+            (None, None) => {}
+        }
+
+        if byte == 255 {
+            if let Some(t) = current_target {
+                ranges.push((range_start, byte, t));
+            }
+        }
+    }
+
+    ranges
+}
+
+/// Emits the dead state code.
+fn emit_dead_state(
+    asm: &mut Assembler,
+    dead_label: DynamicLabel,
+    no_match_label: DynamicLabel,
+    restart_label: Option<DynamicLabel>,
+    dispatch_label: Option<DynamicLabel>,
+    has_word_boundary: bool,
+) -> Result<()> {
+    dynasm!(asm
+        ; .align 4
+        ; =>dead_label
+    );
+
+    if let Some(restart) = restart_label {
+        // Check if we already have a match
+        dynasm!(asm
+            ; cmp x22, #0
+            ; b.ge =>no_match_label
+            // Advance search position
+            ; add x23, x23, #1
+            ; add x9, x20, x23
+            ; cmp x9, x21
+            ; b.hs =>no_match_label
+            // Reset position to search start
+            ; mov x19, x23
+        );
+
+        if has_word_boundary {
+            if let Some(dispatch) = dispatch_label {
+                let is_word = asm.new_dynamic_label();
+                let not_word = asm.new_dynamic_label();
+
+                // Classify byte at position (x23 - 1)
+                dynasm!(asm
+                    ; sub x9, x23, #1
+                    ; ldrb w9, [x20, x9]
+                    ; mov x24, #0              // Assume NonWord
+
+                    // Check 0-9 (0x30-0x39)
+                    ; cmp w9, #0x30
+                    ; b.lo =>not_word
+                    ; cmp w9, #0x39
+                    ; b.ls =>is_word
+
+                    // Check A-Z (0x41-0x5A)
+                    ; cmp w9, #0x41
+                    ; b.lo =>not_word
+                    ; cmp w9, #0x5A
+                    ; b.ls =>is_word
+
+                    // Check _ (0x5F)
+                    ; cmp w9, #0x5F
+                    ; b.eq =>is_word
+
+                    // Check a-z (0x61-0x7A)
+                    ; cmp w9, #0x61
+                    ; b.lo =>not_word
+                    ; cmp w9, #0x7A
+                    ; b.ls =>is_word
+                    ; b =>not_word
+
+                    ; =>is_word
+                    ; mov x24, #1
+
+                    ; =>not_word
+                    ; b =>dispatch
+                );
+            } else {
+                dynasm!(asm
+                    ; b =>restart
+                );
+            }
+        } else {
+            dynasm!(asm
+                ; b =>restart
+            );
+        }
+    } else {
+        // Anchored: no retry
+        dynasm!(asm
+            ; b =>no_match_label
+        );
+    }
+
+    Ok(())
+}
+
+/// Emits the no-match epilogue.
+fn emit_no_match(
+    asm: &mut Assembler,
+    no_match_label: DynamicLabel,
+    _has_word_boundary: bool,
+) -> Result<()> {
+    let truly_no_match = asm.new_dynamic_label();
+    let return_match = asm.new_dynamic_label();
+
+    dynasm!(asm
+        ; =>no_match_label
+        // Check if we have a saved match
+        ; cmp x22, #0
+        ; b.lt =>truly_no_match
+        // Pack result: (x23 << 32) | x22
+        ; lsl x0, x23, #32
+        ; orr x0, x0, x22
+        ; b =>return_match
+
+        ; =>truly_no_match
+        ; movn x0, 0
+
+        ; =>return_match
+        // Restore callee-saved registers
+        ; ldp x23, x24, [sp], #16
+        ; ldp x21, x22, [sp], #16
+        ; ldp x19, x20, [sp], #16
+        ; ldp x29, x30, [sp], #16
+        ; ret
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_arm64_jit_available() {
+        // Basic test that the module compiles
+        assert!(true);
+    }
+}

--- a/src/jit/calling_convention.rs
+++ b/src/jit/calling_convention.rs
@@ -1,0 +1,154 @@
+//! Platform-specific calling convention support for JIT code generation.
+//!
+//! This module provides macros and helpers to generate code that works with both:
+//! - **System V AMD64 ABI** (Linux, macOS, BSD): Args in RDI, RSI, RDX, RCX, R8, R9
+//! - **Microsoft x64 ABI** (Windows): Args in RCX, RDX, R8, R9
+//!
+//! # Key Differences
+//!
+//! | Aspect | System V (Unix) | Microsoft x64 (Windows) |
+//! |--------|-----------------|-------------------------|
+//! | Arg 1 | RDI | RCX |
+//! | Arg 2 | RSI | RDX |
+//! | Arg 3 | RDX | R8 |
+//! | Arg 4 | RCX | R9 |
+//! | Callee-saved | RBX, RBP, R12-R15 | RBX, RBP, RDI, RSI, R12-R15 |
+//! | Shadow space | None | 32 bytes |
+//!
+//! # Usage
+//!
+//! All JIT modules use RDI and RSI internally for position and base pointer.
+//! The prologue handles moving arguments from the platform's calling convention
+//! to these internal registers. On Windows, RDI and RSI must also be saved/restored
+//! since they are callee-saved.
+
+use dynasm::dynasm;
+use dynasmrt::x64::Assembler;
+
+/// Emits the platform-specific function prologue.
+///
+/// After this prologue:
+/// - `rdi` = first argument (input pointer)
+/// - `rsi` = second argument (length)
+///
+/// On Windows, this also saves RDI and RSI (callee-saved) to the stack.
+#[cfg(target_os = "windows")]
+pub fn emit_abi_prologue(asm: &mut Assembler) {
+    dynasm!(asm
+        // Windows x64: args come in RCX, RDX
+        // RDI and RSI are callee-saved on Windows, so we must preserve them
+        ; push rdi
+        ; push rsi
+        // Move arguments to System V registers for internal use
+        ; mov rdi, rcx  // arg1: input ptr
+        ; mov rsi, rdx  // arg2: length
+    );
+}
+
+/// Emits the platform-specific function prologue.
+///
+/// After this prologue:
+/// - `rdi` = first argument (input pointer)
+/// - `rsi` = second argument (length)
+///
+/// On Unix (System V ABI), arguments are already in the correct registers.
+#[cfg(not(target_os = "windows"))]
+pub fn emit_abi_prologue(asm: &mut Assembler) {
+    // System V AMD64: args already in RDI, RSI - nothing to do
+    let _ = asm;
+}
+
+/// Emits the platform-specific function epilogue before return.
+///
+/// On Windows, this restores RDI and RSI from the stack.
+#[cfg(target_os = "windows")]
+pub fn emit_abi_epilogue(asm: &mut Assembler) {
+    dynasm!(asm
+        // Restore callee-saved registers
+        ; pop rsi
+        ; pop rdi
+    );
+}
+
+/// Emits the platform-specific function epilogue before return.
+///
+/// On Unix (System V ABI), no special cleanup is needed.
+#[cfg(not(target_os = "windows"))]
+pub fn emit_abi_epilogue(asm: &mut Assembler) {
+    // System V AMD64: nothing to restore
+    let _ = asm;
+}
+
+/// Emits prologue for functions that also save R13 (word boundary patterns).
+///
+/// On Windows: saves RDI, RSI, R13
+/// On Unix: saves R13
+#[cfg(target_os = "windows")]
+pub fn emit_abi_prologue_with_r13(asm: &mut Assembler) {
+    dynasm!(asm
+        // Windows x64: RDI, RSI, R13 all need saving
+        ; push rdi
+        ; push rsi
+        ; push r13
+        // Move arguments to System V registers
+        ; mov rdi, rcx
+        ; mov rsi, rdx
+    );
+}
+
+/// Emits prologue for functions that also save R13 (word boundary patterns).
+#[cfg(not(target_os = "windows"))]
+pub fn emit_abi_prologue_with_r13(asm: &mut Assembler) {
+    dynasm!(asm
+        // System V: only R13 needs saving (callee-saved)
+        ; push r13
+    );
+}
+
+/// Emits epilogue for functions that saved R13.
+#[cfg(target_os = "windows")]
+pub fn emit_abi_epilogue_with_r13(asm: &mut Assembler) {
+    dynasm!(asm
+        ; pop r13
+        ; pop rsi
+        ; pop rdi
+    );
+}
+
+/// Emits epilogue for functions that saved R13.
+#[cfg(not(target_os = "windows"))]
+pub fn emit_abi_epilogue_with_r13(asm: &mut Assembler) {
+    dynasm!(asm
+        ; pop r13
+    );
+}
+
+/// Returns whether the current platform is Windows.
+#[inline]
+pub const fn is_windows() -> bool {
+    cfg!(target_os = "windows")
+}
+
+/// Returns the calling convention name for the current platform.
+#[inline]
+pub const fn calling_convention_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "Microsoft x64"
+    } else {
+        "System V AMD64"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calling_convention_name() {
+        let name = calling_convention_name();
+        #[cfg(target_os = "windows")]
+        assert_eq!(name, "Microsoft x64");
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(name, "System V AMD64");
+    }
+}

--- a/src/jit/calling_convention.rs
+++ b/src/jit/calling_convention.rs
@@ -1,10 +1,15 @@
 //! Platform-specific calling convention support for JIT code generation.
 //!
-//! This module provides macros and helpers to generate code that works with both:
+//! This module provides macros and helpers to generate code that works with:
+//!
+//! ## x86_64 Platforms
 //! - **System V AMD64 ABI** (Linux, macOS, BSD): Args in RDI, RSI, RDX, RCX, R8, R9
 //! - **Microsoft x64 ABI** (Windows): Args in RCX, RDX, R8, R9
 //!
-//! # Key Differences
+//! ## ARM64 Platforms (AAPCS64)
+//! - **All platforms** (Linux, macOS, Windows): Args in X0, X1, X2, X3, X4, X5, X6, X7
+//!
+//! # x86_64 Key Differences
 //!
 //! | Aspect | System V (Unix) | Microsoft x64 (Windows) |
 //! |--------|-----------------|-------------------------|
@@ -15,24 +20,37 @@
 //! | Callee-saved | RBX, RBP, R12-R15 | RBX, RBP, RDI, RSI, R12-R15 |
 //! | Shadow space | None | 32 bytes |
 //!
+//! # ARM64 (AAPCS64) - Same on all platforms
+//!
+//! | Aspect | Value |
+//! |--------|-------|
+//! | Args 1-8 | X0-X7 |
+//! | Return | X0 (X0:X1 for 128-bit) |
+//! | Callee-saved | X19-X28, X29 (FP), X30 (LR) |
+//! | Stack alignment | 16 bytes |
+//!
 //! # Usage
 //!
-//! All JIT modules use RDI and RSI internally for position and base pointer.
-//! The prologue handles moving arguments from the platform's calling convention
-//! to these internal registers. On Windows, RDI and RSI must also be saved/restored
-//! since they are callee-saved.
+//! All JIT modules use consistent internal registers. The prologue handles
+//! moving arguments from the platform's calling convention to internal registers.
 
+// ============================================================================
+// x86_64 Implementation
+// ============================================================================
+
+#[cfg(target_arch = "x86_64")]
 use dynasm::dynasm;
+#[cfg(target_arch = "x86_64")]
 use dynasmrt::x64::Assembler;
 
-/// Emits the platform-specific function prologue.
+/// Emits the platform-specific function prologue for x86_64.
 ///
 /// After this prologue:
 /// - `rdi` = first argument (input pointer)
 /// - `rsi` = second argument (length)
 ///
 /// On Windows, this also saves RDI and RSI (callee-saved) to the stack.
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub fn emit_abi_prologue(asm: &mut Assembler) {
     dynasm!(asm
         // Windows x64: args come in RCX, RDX
@@ -45,23 +63,23 @@ pub fn emit_abi_prologue(asm: &mut Assembler) {
     );
 }
 
-/// Emits the platform-specific function prologue.
+/// Emits the platform-specific function prologue for x86_64.
 ///
 /// After this prologue:
 /// - `rdi` = first argument (input pointer)
 /// - `rsi` = second argument (length)
 ///
 /// On Unix (System V ABI), arguments are already in the correct registers.
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub fn emit_abi_prologue(asm: &mut Assembler) {
     // System V AMD64: args already in RDI, RSI - nothing to do
     let _ = asm;
 }
 
-/// Emits the platform-specific function epilogue before return.
+/// Emits the platform-specific function epilogue before return for x86_64.
 ///
 /// On Windows, this restores RDI and RSI from the stack.
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub fn emit_abi_epilogue(asm: &mut Assembler) {
     dynasm!(asm
         // Restore callee-saved registers
@@ -70,10 +88,10 @@ pub fn emit_abi_epilogue(asm: &mut Assembler) {
     );
 }
 
-/// Emits the platform-specific function epilogue before return.
+/// Emits the platform-specific function epilogue before return for x86_64.
 ///
 /// On Unix (System V ABI), no special cleanup is needed.
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub fn emit_abi_epilogue(asm: &mut Assembler) {
     // System V AMD64: nothing to restore
     let _ = asm;
@@ -83,7 +101,7 @@ pub fn emit_abi_epilogue(asm: &mut Assembler) {
 ///
 /// On Windows: saves RDI, RSI, R13
 /// On Unix: saves R13
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub fn emit_abi_prologue_with_r13(asm: &mut Assembler) {
     dynasm!(asm
         // Windows x64: RDI, RSI, R13 all need saving
@@ -97,7 +115,7 @@ pub fn emit_abi_prologue_with_r13(asm: &mut Assembler) {
 }
 
 /// Emits prologue for functions that also save R13 (word boundary patterns).
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub fn emit_abi_prologue_with_r13(asm: &mut Assembler) {
     dynasm!(asm
         // System V: only R13 needs saving (callee-saved)
@@ -106,7 +124,7 @@ pub fn emit_abi_prologue_with_r13(asm: &mut Assembler) {
 }
 
 /// Emits epilogue for functions that saved R13.
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub fn emit_abi_epilogue_with_r13(asm: &mut Assembler) {
     dynasm!(asm
         ; pop r13
@@ -116,12 +134,93 @@ pub fn emit_abi_epilogue_with_r13(asm: &mut Assembler) {
 }
 
 /// Emits epilogue for functions that saved R13.
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub fn emit_abi_epilogue_with_r13(asm: &mut Assembler) {
     dynasm!(asm
         ; pop r13
     );
 }
+
+// ============================================================================
+// ARM64 (AArch64) Implementation
+// ============================================================================
+
+#[cfg(target_arch = "aarch64")]
+use dynasm::dynasm;
+#[cfg(target_arch = "aarch64")]
+use dynasmrt::aarch64::Assembler as Aarch64Assembler;
+
+/// Emits the function prologue for ARM64 (AAPCS64).
+///
+/// AAPCS64 is used on all ARM64 platforms (Linux, macOS, Windows).
+///
+/// After this prologue:
+/// - `x19` = first argument (input pointer, moved from x0)
+/// - `x20` = second argument (length, moved from x1)
+///
+/// Saves X19, X20 (callee-saved) to the stack.
+#[cfg(target_arch = "aarch64")]
+pub fn emit_abi_prologue_aarch64(asm: &mut Aarch64Assembler) {
+    dynasm!(asm
+        ; .arch aarch64
+        // Save callee-saved registers we'll use internally
+        // X19-X20 for input ptr and length
+        ; stp x19, x20, [sp, #-16]!
+        // Move arguments to callee-saved registers for internal use
+        ; mov x19, x0  // x19 = input ptr
+        ; mov x20, x1  // x20 = length
+    );
+}
+
+/// Emits the function epilogue for ARM64 (AAPCS64).
+///
+/// Restores X19, X20 from the stack.
+#[cfg(target_arch = "aarch64")]
+pub fn emit_abi_epilogue_aarch64(asm: &mut Aarch64Assembler) {
+    dynasm!(asm
+        ; .arch aarch64
+        // Restore callee-saved registers
+        ; ldp x19, x20, [sp], #16
+    );
+}
+
+/// Emits prologue for ARM64 functions that need additional callee-saved registers.
+///
+/// Saves X19-X24 (6 registers) for complex patterns.
+#[cfg(target_arch = "aarch64")]
+pub fn emit_abi_prologue_full_aarch64(asm: &mut Aarch64Assembler) {
+    dynasm!(asm
+        ; .arch aarch64
+        // Save frame pointer and link register
+        ; stp x29, x30, [sp, #-16]!
+        ; mov x29, sp
+        // Save callee-saved registers we'll use
+        ; stp x19, x20, [sp, #-16]!
+        ; stp x21, x22, [sp, #-16]!
+        ; stp x23, x24, [sp, #-16]!
+        // Move arguments to callee-saved registers
+        ; mov x19, x0  // x19 = input ptr
+        ; mov x20, x1  // x20 = length
+    );
+}
+
+/// Emits epilogue for ARM64 functions that saved full register set.
+#[cfg(target_arch = "aarch64")]
+pub fn emit_abi_epilogue_full_aarch64(asm: &mut Aarch64Assembler) {
+    dynasm!(asm
+        ; .arch aarch64
+        // Restore callee-saved registers in reverse order
+        ; ldp x23, x24, [sp], #16
+        ; ldp x21, x22, [sp], #16
+        ; ldp x19, x20, [sp], #16
+        // Restore frame pointer and link register
+        ; ldp x29, x30, [sp], #16
+    );
+}
+
+// ============================================================================
+// Common helpers
+// ============================================================================
 
 /// Returns whether the current platform is Windows.
 #[inline]
@@ -129,13 +228,33 @@ pub const fn is_windows() -> bool {
     cfg!(target_os = "windows")
 }
 
+/// Returns whether the current architecture is ARM64.
+#[inline]
+pub const fn is_aarch64() -> bool {
+    cfg!(target_arch = "aarch64")
+}
+
 /// Returns the calling convention name for the current platform.
 #[inline]
 pub const fn calling_convention_name() -> &'static str {
-    if cfg!(target_os = "windows") {
+    if cfg!(target_arch = "aarch64") {
+        "AAPCS64"
+    } else if cfg!(target_os = "windows") {
         "Microsoft x64"
     } else {
         "System V AMD64"
+    }
+}
+
+/// Returns the target architecture name.
+#[inline]
+pub const fn arch_name() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else {
+        "unknown"
     }
 }
 
@@ -146,9 +265,20 @@ mod tests {
     #[test]
     fn test_calling_convention_name() {
         let name = calling_convention_name();
-        #[cfg(target_os = "windows")]
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(name, "AAPCS64");
+        #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
         assert_eq!(name, "Microsoft x64");
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
         assert_eq!(name, "System V AMD64");
+    }
+
+    #[test]
+    fn test_arch_name() {
+        let arch = arch_name();
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(arch, "aarch64");
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(arch, "x86_64");
     }
 }

--- a/src/jit/codegen.rs
+++ b/src/jit/codegen.rs
@@ -203,7 +203,7 @@ impl CompiledRegex {
                     return Some((start, end));
                 }
                 for (i, &byte) in input.iter().enumerate() {
-                    if byte == b'\n' && i + 1 <= input.len() {
+                    if byte == b'\n' && i < input.len() {
                         if let Some((start, end)) = self.find_at(input, i + 1) {
                             return Some((start, end));
                         }

--- a/src/jit/codegen_aarch64.rs
+++ b/src/jit/codegen_aarch64.rs
@@ -1,0 +1,448 @@
+//! DFA to machine code compilation for AArch64 (ARM64).
+//!
+//! This module compiles a LazyDFA to native ARM64 machine code using dynasm.
+//! The compiled code is W^X compliant and optimized for performance.
+//!
+//! ## Features
+//!
+//! - Full DFA state machine compilation
+//! - Word boundary and anchor support
+//! - Self-loop optimization
+//! - Dense and sparse transition encoding
+
+use crate::dfa::{CharClass, DfaStateId, LazyDfa};
+use crate::error::{Error, ErrorKind, Result};
+use dynasmrt::{AssemblyOffset, ExecutableBuffer};
+
+// ARM64 DFA JIT enabled
+const ARM64_DFA_JIT_ENABLED: bool = true;
+
+/// A JIT-compiled regex matcher for ARM64.
+///
+/// This struct holds the executable machine code generated from a DFA.
+/// The code is W^X compliant (never RWX) and uses optimal alignment for
+/// ARM64 instruction fetch performance.
+pub struct CompiledRegex {
+    /// The executable buffer containing the compiled machine code.
+    code: ExecutableBuffer,
+    /// Entry point offset into the executable buffer (for NonWord prev_class).
+    entry_point: AssemblyOffset,
+    /// Entry point for Word prev_class (only used when has_word_boundary is true).
+    entry_point_word: Option<AssemblyOffset>,
+    /// Whether this regex has word boundary assertions.
+    pub(crate) has_word_boundary: bool,
+    /// Whether any match state requires a word boundary (\b) at the end.
+    match_needs_word_boundary: bool,
+    /// Whether any match state requires NOT a word boundary (\B) at the end.
+    match_needs_not_word_boundary: bool,
+    /// Whether this regex has anchor assertions (^, $).
+    pub(crate) has_anchors: bool,
+    /// Whether this regex has a start anchor (^).
+    pub(crate) has_start_anchor: bool,
+    /// Whether this regex has an end anchor ($).
+    #[allow(dead_code)]
+    pub(crate) has_end_anchor: bool,
+    /// Whether this regex uses multiline mode for anchors.
+    pub(crate) has_multiline_anchors: bool,
+    /// Whether any match state requires EndOfText assertion.
+    pub(crate) match_needs_end_of_text: bool,
+    /// Whether any match state requires EndOfLine assertion.
+    pub(crate) match_needs_end_of_line: bool,
+}
+
+impl CompiledRegex {
+    /// Executes the compiled regex on the given input with a specific prev_class.
+    fn execute_with_class(&self, input: &[u8], prev_class: CharClass) -> Option<(usize, usize)> {
+        // ARM64 uses AAPCS64 calling convention (extern "C")
+        type MatchFn = unsafe extern "C" fn(*const u8, usize) -> i64;
+
+        let entry = if self.has_word_boundary && prev_class == CharClass::Word {
+            self.entry_point_word.unwrap_or(self.entry_point)
+        } else {
+            self.entry_point
+        };
+
+        let func: MatchFn = unsafe { std::mem::transmute(self.code.ptr(entry)) };
+
+        let result = unsafe { func(input.as_ptr(), input.len()) };
+
+        if result >= 0 {
+            let packed = result as u64;
+            let start_pos = (packed >> 32) as usize;
+            let end_pos = (packed & 0xFFFF_FFFF) as usize;
+
+            if !self.validate_end_assertions(input, start_pos, end_pos, prev_class) {
+                return None;
+            }
+
+            Some((start_pos, end_pos))
+        } else {
+            None
+        }
+    }
+
+    /// Validates that end assertions (word boundaries and anchors) are satisfied.
+    fn validate_end_assertions(
+        &self,
+        input: &[u8],
+        start_pos: usize,
+        end_pos: usize,
+        prev_class: CharClass,
+    ) -> bool {
+        if self.has_word_boundary
+            && (self.match_needs_word_boundary || self.match_needs_not_word_boundary)
+        {
+            let actual_prev_class = if start_pos > 0 {
+                CharClass::from_byte(input[start_pos - 1])
+            } else {
+                prev_class
+            };
+
+            let is_at_boundary = if end_pos == start_pos {
+                if end_pos < input.len() {
+                    actual_prev_class != CharClass::from_byte(input[end_pos])
+                } else {
+                    actual_prev_class != CharClass::NonWord
+                }
+            } else {
+                let last_class = CharClass::from_byte(input[end_pos - 1]);
+                let next_class = if end_pos < input.len() {
+                    CharClass::from_byte(input[end_pos])
+                } else {
+                    CharClass::NonWord
+                };
+                last_class != next_class
+            };
+
+            if self.match_needs_word_boundary && !is_at_boundary {
+                return false;
+            }
+            if self.match_needs_not_word_boundary && is_at_boundary {
+                return false;
+            }
+        }
+
+        if self.has_anchors {
+            if self.match_needs_end_of_text && end_pos != input.len() {
+                return false;
+            }
+            if self.match_needs_end_of_line {
+                let at_end_of_line = end_pos == input.len() || input.get(end_pos) == Some(&b'\n');
+                if !at_end_of_line {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Executes the compiled regex on the given input (assumes NonWord prev_class).
+    pub fn execute(&self, input: &[u8]) -> Option<(usize, usize)> {
+        self.execute_with_class(input, CharClass::NonWord)
+    }
+
+    /// Returns true if the regex matches anywhere in the input (unanchored).
+    pub fn is_match(&self, input: &[u8]) -> bool {
+        self.find(input).is_some()
+    }
+
+    /// Returns true if the regex matches the entire input (anchored).
+    pub fn is_full_match(&self, input: &[u8]) -> bool {
+        match self.execute(input) {
+            Some((start, end)) => start == 0 && end == input.len(),
+            None => false,
+        }
+    }
+
+    /// Finds the first match in the input.
+    pub fn find(&self, input: &[u8]) -> Option<(usize, usize)> {
+        if self.has_start_anchor {
+            if self.has_multiline_anchors {
+                if let Some((start, end)) = self.find_at(input, 0) {
+                    return Some((start, end));
+                }
+                for (i, &byte) in input.iter().enumerate() {
+                    if byte == b'\n' && i + 1 <= input.len() {
+                        if let Some((start, end)) = self.find_at(input, i + 1) {
+                            return Some((start, end));
+                        }
+                    }
+                }
+                None
+            } else {
+                self.find_at(input, 0)
+            }
+        } else {
+            self.execute(input)
+        }
+    }
+
+    /// Finds a match starting at or after the given position.
+    pub fn find_at(&self, input: &[u8], start_pos: usize) -> Option<(usize, usize)> {
+        if start_pos > input.len() {
+            return None;
+        }
+
+        if self.has_start_anchor {
+            let valid_start = if self.has_multiline_anchors {
+                start_pos == 0 || (start_pos > 0 && input[start_pos - 1] == b'\n')
+            } else {
+                start_pos == 0
+            };
+            if !valid_start {
+                return None;
+            }
+        }
+
+        let prev_class = if self.has_word_boundary && start_pos > 0 {
+            CharClass::from_byte(input[start_pos - 1])
+        } else {
+            CharClass::NonWord
+        };
+
+        self.execute_with_class(&input[start_pos..], prev_class)
+            .map(|(rel_start, rel_end)| (start_pos + rel_start, start_pos + rel_end))
+    }
+}
+
+/// JIT compiler for DFA states on ARM64.
+///
+/// This struct handles the conversion of a DFA to native ARM64 machine code.
+pub struct JitCompiler;
+
+impl JitCompiler {
+    /// Creates a new JIT compiler.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Compiles a LazyDFA to native machine code.
+    ///
+    /// This method:
+    /// 1. Forces full DFA materialization by exploring all reachable states
+    /// 2. Allocates dynamic labels for all states
+    /// 3. Emits optimized ARM64 assembly for each state
+    /// 4. Returns an executable buffer (W^X compliant)
+    ///
+    /// # Errors
+    /// Returns an error if DFA materialization fails or assembly generation fails.
+    pub fn compile_dfa(self, dfa: &mut LazyDfa) -> Result<CompiledRegex> {
+        // ARM64 DFA JIT is disabled until assembly is fully debugged
+        if !ARM64_DFA_JIT_ENABLED {
+            return Err(Error::new(
+                ErrorKind::Jit("ARM64 DFA JIT temporarily disabled".to_string()),
+                "",
+            ));
+        }
+
+        // Step 1: Materialize all reachable DFA states
+        let materialized = self.materialize_dfa(dfa)?;
+
+        // ARM64: Limit state count to avoid branch distance issues and code bloat
+        // Large Unicode character classes can create many states
+        const MAX_ARM64_DFA_STATES: usize = 64;
+        if materialized.states.len() > MAX_ARM64_DFA_STATES {
+            return Err(Error::new(
+                ErrorKind::Jit(format!(
+                    "DFA too large for ARM64 JIT ({} states, max {})",
+                    materialized.states.len(),
+                    MAX_ARM64_DFA_STATES
+                )),
+                "",
+            ));
+        }
+
+        // Step 2: Compile to machine code
+        let (code, entry_point, entry_point_word) =
+            crate::jit::aarch64::compile_states(&materialized)?;
+
+        // Collect boundary and anchor requirements from all match states
+        let mut match_needs_word_boundary = false;
+        let mut match_needs_not_word_boundary = false;
+        let mut match_needs_end_of_text = false;
+        let mut match_needs_end_of_line = false;
+        for state in &materialized.states {
+            if state.is_match {
+                match_needs_word_boundary |= state.needs_word_boundary;
+                match_needs_not_word_boundary |= state.needs_not_word_boundary;
+                match_needs_end_of_text |= state.needs_end_of_text;
+                match_needs_end_of_line |= state.needs_end_of_line;
+            }
+        }
+
+        Ok(CompiledRegex {
+            code,
+            entry_point,
+            entry_point_word,
+            has_word_boundary: materialized.has_word_boundary,
+            match_needs_word_boundary,
+            match_needs_not_word_boundary,
+            has_anchors: materialized.has_anchors,
+            has_start_anchor: materialized.has_start_anchor,
+            has_end_anchor: materialized.has_end_anchor,
+            has_multiline_anchors: materialized.has_multiline_anchors,
+            match_needs_end_of_text,
+            match_needs_end_of_line,
+        })
+    }
+
+    /// Materializes all reachable states in the DFA.
+    fn materialize_dfa(&self, dfa: &mut LazyDfa) -> Result<MaterializedDfa> {
+        let has_word_boundary = dfa.has_word_boundary();
+        let has_anchors = dfa.has_anchors();
+        let has_start_anchor = dfa.has_start_anchor();
+        let has_end_anchor = dfa.has_end_anchor();
+        let has_multiline_anchors = dfa.has_multiline_anchors();
+
+        let start_nonword = dfa.get_start_state_for_class(CharClass::NonWord);
+        let start_word = if has_word_boundary {
+            Some(dfa.get_start_state_for_class(CharClass::Word))
+        } else {
+            None
+        };
+
+        let mut materialized = MaterializedDfa {
+            states: Vec::new(),
+            start: start_nonword,
+            start_word,
+            has_word_boundary,
+            has_anchors,
+            has_start_anchor,
+            has_end_anchor,
+            has_multiline_anchors,
+        };
+
+        let mut queue = vec![start_nonword];
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(start_nonword);
+
+        if let Some(sw) = start_word {
+            if visited.insert(sw) {
+                queue.push(sw);
+            }
+        }
+
+        while let Some(state_id) = queue.pop() {
+            let transitions = dfa.compute_all_transitions(state_id);
+
+            for byte in 0..=255u8 {
+                if let Some(next_state) = transitions[byte as usize] {
+                    if visited.insert(next_state) {
+                        queue.push(next_state);
+                    }
+                }
+            }
+
+            let is_match = dfa.is_match(state_id);
+            let (needs_word_boundary, needs_not_word_boundary) =
+                dfa.get_state_boundary_requirements(state_id);
+            let (needs_end_of_text, needs_end_of_line) =
+                dfa.get_state_anchor_requirements(state_id);
+
+            materialized.states.push(MaterializedState {
+                id: state_id,
+                transitions,
+                is_match,
+                needs_word_boundary,
+                needs_not_word_boundary,
+                needs_end_of_text,
+                needs_end_of_line,
+            });
+        }
+
+        materialized.states.sort_by_key(|s| s.id);
+
+        Ok(materialized)
+    }
+}
+
+impl Default for JitCompiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A fully-materialized DFA with all transitions computed.
+pub struct MaterializedDfa {
+    /// All DFA states, sorted by ID.
+    pub states: Vec<MaterializedState>,
+    /// The start state ID (for NonWord prev_class).
+    pub start: DfaStateId,
+    /// The start state ID for Word prev_class (only for word boundary patterns).
+    pub start_word: Option<DfaStateId>,
+    /// Whether this DFA has word boundary assertions.
+    pub has_word_boundary: bool,
+    /// Whether this DFA has anchor assertions (^, $).
+    pub has_anchors: bool,
+    /// Whether this DFA has a start anchor (^).
+    pub has_start_anchor: bool,
+    /// Whether this DFA has an end anchor ($).
+    pub has_end_anchor: bool,
+    /// Whether this DFA uses multiline mode for anchors.
+    pub has_multiline_anchors: bool,
+}
+
+/// A materialized DFA state with all transitions computed.
+#[derive(Debug, Clone)]
+pub struct MaterializedState {
+    /// The state ID.
+    pub id: DfaStateId,
+    /// All 256 transitions (None = dead state).
+    pub transitions: [Option<DfaStateId>; 256],
+    /// Whether this is a match state.
+    pub is_match: bool,
+    /// Whether this state requires a word boundary (\b) at the end.
+    pub needs_word_boundary: bool,
+    /// Whether this state requires NOT a word boundary (\B) at the end.
+    pub needs_not_word_boundary: bool,
+    /// Whether this state requires EndOfText ($) assertion.
+    pub needs_end_of_text: bool,
+    /// Whether this state requires EndOfLine ($) assertion (multiline).
+    pub needs_end_of_line: bool,
+}
+
+impl MaterializedState {
+    /// Analyzes transition density to choose optimal code generation strategy.
+    pub fn transition_density(&self) -> usize {
+        self.transitions.iter().filter(|t| t.is_some()).count()
+    }
+
+    /// Returns true if this state should use a jump table.
+    pub fn should_use_jump_table(&self) -> bool {
+        self.transition_density() > 10
+    }
+
+    /// Groups consecutive transitions to the same target state.
+    pub fn transition_ranges(&self) -> Vec<(u8, u8, DfaStateId)> {
+        let mut ranges = Vec::new();
+        let mut current_target = None;
+        let mut range_start = 0u8;
+
+        for byte in 0..=255u8 {
+            let target = self.transitions[byte as usize];
+
+            match (current_target, target) {
+                (None, Some(t)) => {
+                    current_target = Some(t);
+                    range_start = byte;
+                }
+                (Some(curr), Some(t)) if curr == t => {}
+                (Some(curr), _) => {
+                    ranges.push((range_start, byte - 1, curr));
+                    current_target = target;
+                    range_start = byte;
+                }
+                (None, None) => {}
+            }
+
+            if byte == 255 {
+                if let Some(t) = current_target {
+                    ranges.push((range_start, byte, t));
+                }
+            }
+        }
+
+        ranges
+    }
+}

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -1,6 +1,6 @@
 //! JIT compilation module for regex patterns.
 //!
-//! This module compiles DFA states to native x86-64 machine code using dynasm.
+//! This module compiles DFA states to native machine code using dynasm.
 //! The JIT compiler provides significant performance improvements for repeated
 //! pattern matching operations.
 //!
@@ -9,12 +9,12 @@
 //! - **W^X Compliant**: Generated code is never RWX (read-write-execute)
 //! - **Optimized**: 16-byte alignment for hot loops, efficient transition encoding
 //! - **Safe**: Memory-safe API wrapping unsafe JIT execution
-//! - **Cross-platform**: Supports both System V AMD64 (Unix) and Microsoft x64 (Windows) ABIs
+//! - **Cross-platform**: Supports x86_64 (Windows, Linux, macOS) and ARM64 (Linux, macOS, Windows)
 //!
 //! # Architecture Support
 //!
-//! Currently only x86-64 is supported. The module is conditionally compiled
-//! based on the `jit` feature and target architecture.
+//! - **x86_64**: System V AMD64 ABI (Unix) and Microsoft x64 ABI (Windows)
+//! - **aarch64**: AAPCS64 (all platforms)
 //!
 //! # Example
 //!
@@ -42,50 +42,64 @@
 //! # }
 //! ```
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+// Calling convention helpers (available on both architectures)
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod calling_convention;
 
+// x86_64 backend
 #[cfg(all(feature = "jit", target_arch = "x86_64"))]
 mod codegen;
 
 #[cfg(all(feature = "jit", target_arch = "x86_64"))]
 mod x86_64;
 
+// aarch64 backend
+#[cfg(all(feature = "jit", target_arch = "aarch64"))]
+mod codegen_aarch64;
+
+#[cfg(all(feature = "jit", target_arch = "aarch64"))]
+mod aarch64;
+
+// Re-exports for x86_64
 #[cfg(all(feature = "jit", target_arch = "x86_64"))]
 pub use codegen::{CompiledRegex, JitCompiler, MaterializedDfa, MaterializedState};
 
+// Re-exports for aarch64
+#[cfg(all(feature = "jit", target_arch = "aarch64"))]
+pub use codegen_aarch64::{CompiledRegex, JitCompiler, MaterializedDfa, MaterializedState};
+
 // Re-export liveness types from nfa::tagged (the canonical location)
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use crate::nfa::tagged::liveness::{
     analyze_liveness, CaptureBitSet, NfaLiveness, StateLiveness,
 };
 
 // Re-export TaggedNfaJit from nfa::tagged::jit (the canonical location)
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use crate::nfa::tagged::jit::{compile_tagged_nfa, TaggedNfaJit};
 
 // Re-export BacktrackingJit from vm::backtracking::jit (the canonical location)
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use crate::vm::backtracking::jit::{compile_backtracking, BacktrackingJit};
 
 // Re-export JitShiftOr from vm::shift_or::jit (the canonical location)
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use crate::vm::shift_or::jit::JitShiftOr;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 use crate::dfa::LazyDfa;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 use crate::error::Result;
 
-/// Compiles a LazyDFA to native x86-64 machine code.
+/// Compiles a LazyDFA to native machine code.
 ///
 /// This is the main entry point for JIT compilation. It takes a LazyDFA
 /// and returns a CompiledRegex that can be executed directly on the CPU.
 ///
 /// # Platform Support
 ///
-/// This function is only available on x86-64 platforms with the `jit` feature enabled.
+/// This function is available on x86-64 and ARM64 platforms with the `jit` feature enabled.
 ///
 /// # Errors
 ///
@@ -114,7 +128,7 @@ use crate::error::Result;
 /// # Ok(())
 /// # }
 /// ```
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub fn compile_dfa(dfa: &mut LazyDfa) -> Result<CompiledRegex> {
     let compiler = JitCompiler::new();
     compiler.compile_dfa(dfa)
@@ -122,8 +136,9 @@ pub fn compile_dfa(dfa: &mut LazyDfa) -> Result<CompiledRegex> {
 
 /// Returns true if JIT compilation is available on this platform.
 ///
-/// JIT is available on x86-64 systems (Windows, Linux, macOS) with the `jit` feature enabled.
-/// Both System V AMD64 ABI (Unix) and Microsoft x64 ABI (Windows) are supported.
+/// JIT is available on:
+/// - x86-64 systems (Windows, Linux, macOS) with the `jit` feature enabled
+/// - ARM64 systems (Linux, macOS, Windows) with the `jit` feature enabled
 ///
 /// # Example
 ///
@@ -136,15 +151,20 @@ pub fn compile_dfa(dfa: &mut LazyDfa) -> Result<CompiledRegex> {
 /// }
 /// ```
 pub const fn is_available() -> bool {
-    cfg!(all(feature = "jit", target_arch = "x86_64"))
+    cfg!(all(
+        feature = "jit",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))
 }
 
 /// Returns the target architecture for JIT compilation.
 ///
-/// Returns `Some("x86_64")` if JIT is available, `None` otherwise.
+/// Returns `Some("x86_64")` or `Some("aarch64")` if JIT is available, `None` otherwise.
 pub const fn target_arch() -> Option<&'static str> {
-    if is_available() {
+    if cfg!(all(feature = "jit", target_arch = "x86_64")) {
         Some("x86_64")
+    } else if cfg!(all(feature = "jit", target_arch = "aarch64")) {
+        Some("aarch64")
     } else {
         None
     }
@@ -159,10 +179,10 @@ mod tests {
         // Test should pass on all platforms
         let available = is_available();
 
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         assert!(available);
 
-        #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+        #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
         assert!(!available);
     }
 
@@ -173,7 +193,10 @@ mod tests {
         #[cfg(all(feature = "jit", target_arch = "x86_64"))]
         assert_eq!(arch, Some("x86_64"));
 
-        #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+        #[cfg(all(feature = "jit", target_arch = "aarch64"))]
+        assert_eq!(arch, Some("aarch64"));
+
+        #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
         assert_eq!(arch, None);
     }
 }

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -9,6 +9,7 @@
 //! - **W^X Compliant**: Generated code is never RWX (read-write-execute)
 //! - **Optimized**: 16-byte alignment for hot loops, efficient transition encoding
 //! - **Safe**: Memory-safe API wrapping unsafe JIT execution
+//! - **Cross-platform**: Supports both System V AMD64 (Unix) and Microsoft x64 (Windows) ABIs
 //!
 //! # Architecture Support
 //!
@@ -40,6 +41,9 @@
 //! # Ok(())
 //! # }
 //! ```
+
+#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+pub mod calling_convention;
 
 #[cfg(all(feature = "jit", target_arch = "x86_64"))]
 mod codegen;
@@ -118,7 +122,8 @@ pub fn compile_dfa(dfa: &mut LazyDfa) -> Result<CompiledRegex> {
 
 /// Returns true if JIT compilation is available on this platform.
 ///
-/// JIT is only available on x86-64 with the `jit` feature enabled.
+/// JIT is available on x86-64 systems (Windows, Linux, macOS) with the `jit` feature enabled.
+/// Both System V AMD64 ABI (Unix) and Microsoft x64 ABI (Windows) are supported.
 ///
 /// # Example
 ///

--- a/src/jit/x86_64.rs
+++ b/src/jit/x86_64.rs
@@ -336,6 +336,7 @@ fn emit_dispatch(
 ///
 /// The ranges are the byte ranges that self-loop, and other_targets are
 /// non-self-loop transitions that need to be checked after the fast-forward.
+#[allow(clippy::type_complexity)]
 fn analyze_self_loop(
     state: &MaterializedState,
 ) -> Option<(Vec<(u8, u8)>, Vec<(u8, u8, DfaStateId)>)> {
@@ -1073,9 +1074,9 @@ mod tests {
     #[test]
     fn test_contiguous_range() {
         assert!(is_contiguous_range(&[1, 2, 3, 4]));
-        assert!(is_contiguous_range(&[b'a', b'b', b'c']));
+        assert!(is_contiguous_range(b"abc"));
         assert!(!is_contiguous_range(&[1, 2, 4, 5]));
-        assert!(!is_contiguous_range(&[b'a', b'c']));
+        assert!(!is_contiguous_range(b"ac"));
         assert!(is_contiguous_range(&[42]));
         assert!(is_contiguous_range(&[]));
     }
@@ -1083,6 +1084,6 @@ mod tests {
     #[test]
     fn test_unsorted_contiguous() {
         assert!(is_contiguous_range(&[3, 1, 2, 4]));
-        assert!(is_contiguous_range(&[b'c', b'a', b'b']));
+        assert!(is_contiguous_range(b"cab"));
     }
 }

--- a/src/jit/x86_64.rs
+++ b/src/jit/x86_64.rs
@@ -2,6 +2,12 @@
 //!
 //! This module emits native x86-64 assembly code for DFA state machines.
 //! All code is W^X compliant and optimized for performance.
+//!
+//! # Platform Support
+//!
+//! Supports both calling conventions:
+//! - **System V AMD64 ABI** (Linux, macOS, BSD): Args in RDI, RSI
+//! - **Microsoft x64 ABI** (Windows): Args in RCX, RDX
 
 use crate::dfa::DfaStateId;
 use crate::error::{Error, ErrorKind, Result};
@@ -13,7 +19,16 @@ use dynasmrt::{
 
 /// Compiles a materialized DFA to x86-64 machine code.
 ///
-/// # Calling Convention (System V AMD64 ABI)
+/// # Calling Convention
+///
+/// The function accepts two arguments:
+/// - Arg 1: input pointer (const uint8_t*)
+/// - Arg 2: length (size_t)
+///
+/// On Unix (System V AMD64): args in RDI, RSI
+/// On Windows (Microsoft x64): args in RCX, RDX
+///
+/// # Internal Register Usage
 /// - `rdi` = current position in input (mutable, incremented during execution)
 /// - `rsi` = input base pointer (immutable)
 /// - `rdx` = input end pointer (base + len, immutable)
@@ -146,7 +161,7 @@ pub fn compile_states(
 
 /// Emits the function prologue.
 ///
-/// This sets up the calling convention:
+/// This sets up the internal register convention:
 /// - rdi = current position (starts at 0)
 /// - rsi = input base pointer (from first argument)
 /// - rdx = input end pointer (base + len)
@@ -154,6 +169,11 @@ pub fn compile_states(
 /// - r11 = search start position (for unanchored search, tracks where current attempt began)
 /// - r13 = prev_char_class (0 = NonWord, 1 = Word) for word boundary patterns
 /// - Jump to the specified start state
+///
+/// # Platform Differences
+///
+/// - **Unix (System V AMD64)**: Args in RDI, RSI. R13 is callee-saved.
+/// - **Windows (Microsoft x64)**: Args in RCX, RDX. RDI, RSI, R13 are all callee-saved.
 ///
 /// The restart_label is for unanchored patterns - when we fail to match,
 /// we increment r11 and restart from the start state.
@@ -180,37 +200,54 @@ fn emit_prologue(
             )
         })?;
 
-    // For word boundary patterns, save r13 (callee-saved register in System V ABI)
-    // Each entry point (primary and secondary) must save r13 since both can be called independently
-    if has_word_boundary {
+    // Platform-specific prologue: save callee-saved registers and move args
+    #[cfg(target_os = "windows")]
+    {
+        // Windows x64: RDI, RSI are callee-saved. Args come in RCX, RDX.
         dynasm!(asm
-            ; push r13  // Save callee-saved register
+            ; push rdi
+            ; push rsi
+        );
+        if has_word_boundary {
+            dynasm!(asm
+                ; push r13
+            );
+        }
+        // Move arguments: RCX -> R8 (temp for input ptr), RDX = len
+        dynasm!(asm
+            ; mov r8, rcx   // Save input ptr to r8
+            ; lea rdx, [rcx + rdx]  // end = input + len (rdx was len)
+            ; mov rsi, r8   // base = input ptr
+            ; xor rdi, rdi  // pos = 0
+            ; mov r10, -1i32 as _   // last match = -1
+            ; xor r11, r11  // search start = 0
         );
     }
 
-    dynasm!(asm
-        // Function entry point
-        // Arguments: rdi = input ptr, rsi = len
-        // We need to set up: rdi = pos, rsi = base, rdx = end, r10 = -1, r11 = 0
-
-        // Save original input pointer to r8 temporarily
-        ; mov r8, rdi
-
-        // Calculate end pointer: rdx = rdi + rsi
-        ; lea rdx, [rdi + rsi]
-
-        // Set up base pointer: rsi = original rdi (now in r8)
-        ; mov rsi, r8
-
-        // Initialize position to 0: rdi = 0
-        ; xor rdi, rdi
-
-        // Initialize last match position to -1: r10 = -1
-        ; mov r10, -1
-
-        // Initialize search start position to 0: r11 = 0
-        ; xor r11, r11
-    );
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Unix (System V AMD64): Args in RDI, RSI. Only R13 is callee-saved.
+        if has_word_boundary {
+            dynasm!(asm
+                ; push r13
+            );
+        }
+        dynasm!(asm
+            // Arguments: rdi = input ptr, rsi = len
+            // Save original input pointer to r8 temporarily
+            ; mov r8, rdi
+            // Calculate end pointer: rdx = rdi + rsi
+            ; lea rdx, [rdi + rsi]
+            // Set up base pointer: rsi = original rdi (now in r8)
+            ; mov rsi, r8
+            // Initialize position to 0: rdi = 0
+            ; xor rdi, rdi
+            // Initialize last match position to -1: r10 = -1
+            ; mov r10, -1i32 as _
+            // Initialize search start position to 0: r11 = 0
+            ; xor r11, r11
+        );
+    }
 
     // For word boundary patterns, initialize r13 = prev_char_class
     // r13 = 0 means NonWord (start of input or after non-word char)
@@ -941,7 +978,11 @@ fn emit_dead_state(
 /// Otherwise, returns -1 to indicate no match.
 ///
 /// The start position is tracked in r11 (updated on each restart for unanchored search).
-/// For word boundary patterns, we need to restore r13 before returning.
+///
+/// # Platform Differences
+///
+/// - **Unix**: Only R13 needs restoring (for word boundary patterns)
+/// - **Windows**: RDI, RSI, and R13 (if word boundary) need restoring
 fn emit_no_match(
     asm: &mut Assembler,
     no_match_label: DynamicLabel,
@@ -959,25 +1000,47 @@ fn emit_no_match(
         ; or rax, r10
     );
 
-    // Restore r13 before returning (only for word boundary patterns)
-    if has_word_boundary {
+    // Restore callee-saved registers before returning
+    #[cfg(target_os = "windows")]
+    {
+        if has_word_boundary {
+            dynasm!(asm ; pop r13);
+        }
         dynasm!(asm
-            ; pop r13
+            ; pop rsi
+            ; pop rdi
         );
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        if has_word_boundary {
+            dynasm!(asm ; pop r13);
+        }
     }
 
     dynasm!(asm
         ; ret
         ; truly_no_match:
         // No match at all
-        ; mov rax, -1
+        ; mov rax, -1i32 as _
     );
 
-    // Restore r13 before returning (only for word boundary patterns)
-    if has_word_boundary {
+    // Restore callee-saved registers before returning
+    #[cfg(target_os = "windows")]
+    {
+        if has_word_boundary {
+            dynasm!(asm ; pop r13);
+        }
         dynasm!(asm
-            ; pop r13
+            ; pop rsi
+            ; pop rdi
         );
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        if has_word_boundary {
+            dynasm!(asm ; pop r13);
+        }
     }
 
     dynasm!(asm

--- a/src/nfa/glushkov.rs
+++ b/src/nfa/glushkov.rs
@@ -21,7 +21,7 @@ pub const MAX_POSITIONS_WIDE: usize = 256;
 /// Operations are implemented to work efficiently with the Shift-Or algorithm.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BitSet256 {
-    /// 4 x u64 for 256 bits. parts[0] holds bits 0-63, parts[1] holds bits 64-127, etc.
+    /// 4 x u64 for 256 bits. `parts[0]` holds bits 0-63, `parts[1]` holds bits 64-127, etc.
     pub parts: [u64; 4],
 }
 

--- a/src/nfa/tagged/jit/aarch64.rs
+++ b/src/nfa/tagged/jit/aarch64.rs
@@ -1,0 +1,1650 @@
+//! AArch64 JIT code generation for Tagged NFA.
+//!
+//! This module contains the TaggedNfaJitCompiler which generates AArch64 assembly
+//! code for Thompson NFA simulation with captures.
+
+use crate::error::{Error, ErrorKind, Result};
+use crate::hir::CodepointClass;
+use crate::nfa::{ByteClass, ByteRange, Nfa, NfaInstruction, StateId};
+
+use super::super::{NfaLiveness, PatternStep, TaggedNfaContext};
+use super::jit::TaggedNfaJit;
+
+use dynasmrt::{dynasm, DynasmApi};
+
+/// Internal compiler for Tagged NFA JIT on AArch64.
+///
+/// Register allocation (AAPCS64):
+/// - x0-x7 = argument/result registers
+/// - x9-x15 = scratch registers (caller-saved)
+/// - x19-x28 = callee-saved registers
+/// - x30 = link register (LR)
+///
+/// Pattern matching registers:
+/// - x19 = input_ptr (callee-saved)
+/// - x20 = input_len (callee-saved)
+/// - x21 = start_pos (callee-saved)
+/// - x22 = current_pos (callee-saved)
+/// - x23 = captures_out pointer (in captures_fn) / saved_pos (in find_fn)
+/// - w0/x0 = scratch / return value
+#[allow(dead_code)]
+pub(super) struct TaggedNfaJitCompiler {
+    asm: dynasmrt::aarch64::Assembler,
+    nfa: Nfa,
+    liveness: NfaLiveness,
+    state_labels: Vec<dynasmrt::DynamicLabel>,
+    thread_loop_label: dynasmrt::DynamicLabel,
+    advance_pos_label: dynasmrt::DynamicLabel,
+    match_found_label: dynasmrt::DynamicLabel,
+    done_label: dynasmrt::DynamicLabel,
+    add_thread_label: dynasmrt::DynamicLabel,
+    codepoint_classes: Vec<Box<CodepointClass>>,
+    lookaround_nfas: Vec<Box<Nfa>>,
+}
+
+impl TaggedNfaJitCompiler {
+    #[allow(dead_code)]
+    fn new(nfa: Nfa, liveness: NfaLiveness) -> Result<Self> {
+        use dynasmrt::DynasmLabelApi;
+
+        let mut asm = dynasmrt::aarch64::Assembler::new().map_err(|e| {
+            Error::new(
+                ErrorKind::Jit(format!("Failed to create assembler: {:?}", e)),
+                "",
+            )
+        })?;
+
+        let state_labels: Vec<_> = (0..nfa.states.len())
+            .map(|_| asm.new_dynamic_label())
+            .collect();
+
+        let thread_loop_label = asm.new_dynamic_label();
+        let advance_pos_label = asm.new_dynamic_label();
+        let match_found_label = asm.new_dynamic_label();
+        let done_label = asm.new_dynamic_label();
+        let add_thread_label = asm.new_dynamic_label();
+
+        Ok(Self {
+            asm,
+            nfa,
+            liveness,
+            state_labels,
+            thread_loop_label,
+            advance_pos_label,
+            match_found_label,
+            done_label,
+            add_thread_label,
+            codepoint_classes: Vec::new(),
+            lookaround_nfas: Vec::new(),
+        })
+    }
+
+    fn needs_interpreter_fallback(&self) -> bool {
+        if self.nfa.states.len() > 256 {
+            return true;
+        }
+        false
+    }
+
+    pub(super) fn compile(nfa: Nfa, liveness: NfaLiveness) -> Result<TaggedNfaJit> {
+        let compiler = Self::new(nfa, liveness)?;
+        if compiler.needs_interpreter_fallback() {
+            return compiler.compile_with_fallback(None);
+        }
+        compiler.compile_full()
+    }
+
+    fn compile_with_fallback(mut self, steps: Option<Vec<PatternStep>>) -> Result<TaggedNfaJit> {
+        let find_offset = self.asm.offset();
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; movn x0, 1            // x0 = -2
+            ; ret
+        );
+
+        let captures_offset = self.asm.offset();
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; movn x0, 1
+            ; ret
+        );
+
+        self.finalize(find_offset, captures_offset, false, steps)
+    }
+
+    fn has_backref(steps: &[PatternStep]) -> bool {
+        steps.iter().any(|s| match s {
+            PatternStep::Backref(_) => true,
+            PatternStep::Alt(alts) => alts.iter().any(|alt| Self::has_backref(alt)),
+            _ => false,
+        })
+    }
+
+    fn has_unsupported_in_alt(alternatives: &[Vec<PatternStep>]) -> bool {
+        for alt_steps in alternatives {
+            for step in alt_steps {
+                match step {
+                    PatternStep::Alt(inner) => {
+                        if Self::has_unsupported_in_alt(inner) {
+                            return true;
+                        }
+                    }
+                    PatternStep::NonGreedyPlus(_, _) | PatternStep::NonGreedyStar(_, _) => {
+                        return true;
+                    }
+                    PatternStep::PositiveLookahead(_)
+                    | PatternStep::NegativeLookahead(_)
+                    | PatternStep::PositiveLookbehind(_, _)
+                    | PatternStep::NegativeLookbehind(_, _) => return true,
+                    _ => {}
+                }
+            }
+        }
+        false
+    }
+
+    fn step_consumes_input(step: &PatternStep) -> bool {
+        match step {
+            PatternStep::Byte(_)
+            | PatternStep::ByteClass(_)
+            | PatternStep::GreedyPlus(_)
+            | PatternStep::GreedyStar(_)
+            | PatternStep::GreedyCodepointPlus(_)
+            | PatternStep::CodepointClass(_, _)
+            | PatternStep::NonGreedyPlus(_, _)
+            | PatternStep::NonGreedyStar(_, _)
+            | PatternStep::GreedyPlusLookahead(_, _, _)
+            | PatternStep::GreedyStarLookahead(_, _, _)
+            | PatternStep::Backref(_) => true,
+            PatternStep::Alt(alts) => alts.iter().any(|a| a.iter().any(|s| Self::step_consumes_input(s))),
+            _ => false,
+        }
+    }
+
+    fn calc_min_len(steps: &[PatternStep]) -> usize {
+        steps.iter().map(|s| match s {
+            PatternStep::Byte(_) | PatternStep::ByteClass(_) => 1,
+            PatternStep::GreedyPlus(_) | PatternStep::GreedyPlusLookahead(_, _, _) => 1,
+            PatternStep::GreedyStar(_) | PatternStep::GreedyStarLookahead(_, _, _) => 0,
+            PatternStep::NonGreedyPlus(_, suf) => 1 + Self::calc_min_len(&[(**suf).clone()]),
+            PatternStep::NonGreedyStar(_, suf) => Self::calc_min_len(&[(**suf).clone()]),
+            PatternStep::Alt(alts) => alts.iter().map(|a| Self::calc_min_len(a)).min().unwrap_or(0),
+            PatternStep::CodepointClass(_, _) | PatternStep::GreedyCodepointPlus(_) => 1,
+            _ => 0,
+        }).sum()
+    }
+
+    fn combine_greedy_with_lookahead(steps: Vec<PatternStep>) -> Vec<PatternStep> {
+        let mut result = Vec::with_capacity(steps.len());
+        let mut i = 0;
+        while i < steps.len() {
+            match &steps[i] {
+                PatternStep::GreedyPlus(r) if i + 1 < steps.len() => {
+                    match &steps[i + 1] {
+                        PatternStep::PositiveLookahead(inner) => {
+                            result.push(PatternStep::GreedyPlusLookahead(r.clone(), inner.clone(), true));
+                            i += 2; continue;
+                        }
+                        PatternStep::NegativeLookahead(inner) => {
+                            result.push(PatternStep::GreedyPlusLookahead(r.clone(), inner.clone(), false));
+                            i += 2; continue;
+                        }
+                        _ => {}
+                    }
+                }
+                PatternStep::GreedyStar(r) if i + 1 < steps.len() => {
+                    match &steps[i + 1] {
+                        PatternStep::PositiveLookahead(inner) => {
+                            result.push(PatternStep::GreedyStarLookahead(r.clone(), inner.clone(), true));
+                            i += 2; continue;
+                        }
+                        PatternStep::NegativeLookahead(inner) => {
+                            result.push(PatternStep::GreedyStarLookahead(r.clone(), inner.clone(), false));
+                            i += 2; continue;
+                        }
+                        _ => {}
+                    }
+                }
+                PatternStep::Alt(alts) => {
+                    let combined: Vec<Vec<PatternStep>> = alts.iter()
+                        .map(|a| Self::combine_greedy_with_lookahead(a.clone())).collect();
+                    result.push(PatternStep::Alt(combined));
+                    i += 1; continue;
+                }
+                _ => {}
+            }
+            result.push(steps[i].clone());
+            i += 1;
+        }
+        result
+    }
+
+    fn emit_range_check(&mut self, ranges: &[ByteRange], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        if ranges.len() == 1 {
+            let r = &ranges[0];
+            let sz = r.end.wrapping_sub(r.start);
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; sub w1, w0, r.start as u32
+                ; cmp w1, sz as u32
+                ; b.hi =>fail_label
+            );
+        } else {
+            let matched = self.asm.new_dynamic_label();
+            for (ri, r) in ranges.iter().enumerate() {
+                let sz = r.end.wrapping_sub(r.start);
+                if ri == ranges.len() - 1 {
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; sub w1, w0, r.start as u32
+                        ; cmp w1, sz as u32
+                        ; b.hi =>fail_label
+                    );
+                } else {
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; sub w1, w0, r.start as u32
+                        ; cmp w1, sz as u32
+                        ; b.ls =>matched
+                    );
+                }
+            }
+            dynasm!(self.asm ; .arch aarch64 ; =>matched);
+        }
+        Ok(())
+    }
+
+    fn emit_is_word_char(&mut self, word_label: dynasmrt::DynamicLabel, not_word_label: dynasmrt::DynamicLabel) {
+        use dynasmrt::DynasmLabelApi;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; sub w1, w0, 0x61
+            ; cmp w1, 25
+            ; b.ls =>word_label
+            ; sub w1, w0, 0x41
+            ; cmp w1, 25
+            ; b.ls =>word_label
+            ; sub w1, w0, 0x30
+            ; cmp w1, 9
+            ; b.ls =>word_label
+            ; cmp w0, 0x5f
+            ; b.eq =>word_label
+            ; b =>not_word_label
+        );
+    }
+
+    fn emit_word_boundary_check(&mut self, fail_label: dynasmrt::DynamicLabel, is_boundary: bool) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let prev_word = self.asm.new_dynamic_label();
+        let prev_not_word = self.asm.new_dynamic_label();
+        let curr_word = self.asm.new_dynamic_label();
+        let curr_not_word = self.asm.new_dynamic_label();
+        let check_curr = self.asm.new_dynamic_label();
+        let boundary_match = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; cbz x22, =>prev_not_word
+            ; sub x1, x22, 1
+            ; ldrb w0, [x19, x1]
+        );
+        self.emit_is_word_char(prev_word, prev_not_word);
+        dynasm!(self.asm ; .arch aarch64 ; =>prev_word ; mov w9, 1 ; b =>check_curr);
+        dynasm!(self.asm ; .arch aarch64 ; =>prev_not_word ; mov w9, 0);
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>check_curr
+            ; cmp x22, x20
+            ; b.ge =>curr_not_word
+            ; ldrb w0, [x19, x22]
+        );
+        self.emit_is_word_char(curr_word, curr_not_word);
+        dynasm!(self.asm ; .arch aarch64 ; =>curr_word ; mov w10, 1 ; b =>boundary_match);
+        dynasm!(self.asm ; .arch aarch64 ; =>curr_not_word ; mov w10, 0);
+        dynasm!(self.asm ; .arch aarch64 ; =>boundary_match ; eor w9, w9, w10);
+        if is_boundary {
+            dynasm!(self.asm ; .arch aarch64 ; cbz w9, =>fail_label);
+        } else {
+            dynasm!(self.asm ; .arch aarch64 ; cbnz w9, =>fail_label);
+        }
+        Ok(())
+    }
+
+    fn emit_utf8_decode(&mut self, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let ascii = self.asm.new_dynamic_label();
+        let two_byte = self.asm.new_dynamic_label();
+        let three_byte = self.asm.new_dynamic_label();
+        let four_byte = self.asm.new_dynamic_label();
+        let done = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; cmp x22, x20
+            ; b.ge =>fail_label
+            ; ldrb w0, [x19, x22]
+            ; cmp w0, 0x80
+            ; b.lo =>ascii
+            ; cmp w0, 0xC0
+            ; b.lo =>fail_label
+            ; cmp w0, 0xE0
+            ; b.lo =>two_byte
+            ; cmp w0, 0xF0
+            ; b.lo =>three_byte
+            ; cmp w0, 0xF8
+            ; b.lo =>four_byte
+            ; b =>fail_label
+        );
+        dynasm!(self.asm ; .arch aarch64 ; =>ascii ; mov w1, 1 ; b =>done);
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>two_byte
+            ; add x2, x22, 1
+            ; cmp x2, x20
+            ; b.ge =>fail_label
+            ; ldrb w3, [x19, x2]
+            ; and w4, w3, 0xC0
+            ; cmp w4, 0x80
+            ; b.ne =>fail_label
+            ; and w0, w0, 0x1F
+            ; lsl w0, w0, 6
+            ; and w3, w3, 0x3F
+            ; orr w0, w0, w3
+            ; mov w1, 2
+            ; b =>done
+        );
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>three_byte
+            ; add x2, x22, 2
+            ; cmp x2, x20
+            ; b.ge =>fail_label
+            ; add x4, x22, 1
+            ; ldrb w3, [x19, x4]
+            ; and w5, w3, 0xC0
+            ; cmp w5, 0x80
+            ; b.ne =>fail_label
+            ; ldrb w4, [x19, x2]
+            ; and w5, w4, 0xC0
+            ; cmp w5, 0x80
+            ; b.ne =>fail_label
+            ; and w0, w0, 0x0F
+            ; lsl w0, w0, 12
+            ; and w3, w3, 0x3F
+            ; lsl w3, w3, 6
+            ; orr w0, w0, w3
+            ; and w4, w4, 0x3F
+            ; orr w0, w0, w4
+            ; mov w1, 3
+            ; b =>done
+        );
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>four_byte
+            ; add x2, x22, 3
+            ; cmp x2, x20
+            ; b.ge =>fail_label
+            ; add x4, x22, 1
+            ; ldrb w3, [x19, x4]
+            ; and w5, w3, 0xC0
+            ; cmp w5, 0x80
+            ; b.ne =>fail_label
+            ; add x4, x22, 2
+            ; ldrb w4, [x19, x4]
+            ; and w5, w4, 0xC0
+            ; cmp w5, 0x80
+            ; b.ne =>fail_label
+            ; ldrb w5, [x19, x2]
+            ; and w6, w5, 0xC0
+            ; cmp w6, 0x80
+            ; b.ne =>fail_label
+            ; and w0, w0, 0x07
+            ; lsl w0, w0, 18
+            ; and w3, w3, 0x3F
+            ; lsl w3, w3, 12
+            ; orr w0, w0, w3
+            ; and w4, w4, 0x3F
+            ; lsl w4, w4, 6
+            ; orr w0, w0, w4
+            ; and w5, w5, 0x3F
+            ; orr w0, w0, w5
+            ; mov w1, 4
+        );
+        dynasm!(self.asm ; .arch aarch64 ; =>done);
+        Ok(())
+    }
+
+    fn emit_codepoint_class_membership_check(&mut self, cpclass: &CodepointClass, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let ascii_fast = self.asm.new_dynamic_label();
+        let check_done = self.asm.new_dynamic_label();
+        let bitmap_lo = cpclass.ascii_bitmap[0];
+        let bitmap_hi = cpclass.ascii_bitmap[1];
+        let is_negated = cpclass.negated;
+
+        dynasm!(self.asm ; .arch aarch64 ; cmp w0, 128 ; b.lo =>ascii_fast);
+
+        let cpclass_box = Box::new(cpclass.clone());
+        let cpclass_ptr = cpclass_box.as_ref() as *const CodepointClass;
+        self.codepoint_classes.push(cpclass_box);
+
+        extern "C" fn check_membership(cp: u32, cls: *const CodepointClass) -> bool {
+            unsafe { &*cls }.contains(cp)
+        }
+        let fn_ptr = check_membership as usize as u64;
+        let cpclass_ptr_u64 = cpclass_ptr as u64;
+
+        // Split 64-bit pointers into 16-bit chunks for movz/movk (ARM64 requirement)
+        let cls_lo = (cpclass_ptr_u64 & 0xFFFF) as u32;
+        let cls_16 = ((cpclass_ptr_u64 >> 16) & 0xFFFF) as u32;
+        let cls_32 = ((cpclass_ptr_u64 >> 32) & 0xFFFF) as u32;
+        let cls_48 = ((cpclass_ptr_u64 >> 48) & 0xFFFF) as u32;
+
+        let fn_lo = (fn_ptr & 0xFFFF) as u32;
+        let fn_16 = ((fn_ptr >> 16) & 0xFFFF) as u32;
+        let fn_32 = ((fn_ptr >> 32) & 0xFFFF) as u32;
+        let fn_48 = ((fn_ptr >> 48) & 0xFFFF) as u32;
+
+        // Split bitmap values into 16-bit chunks
+        let bm_lo_0 = (bitmap_lo & 0xFFFF) as u32;
+        let bm_lo_16 = ((bitmap_lo >> 16) & 0xFFFF) as u32;
+        let bm_lo_32 = ((bitmap_lo >> 32) & 0xFFFF) as u32;
+        let bm_lo_48 = ((bitmap_lo >> 48) & 0xFFFF) as u32;
+
+        let bm_hi_0 = (bitmap_hi & 0xFFFF) as u32;
+        let bm_hi_16 = ((bitmap_hi >> 16) & 0xFFFF) as u32;
+        let bm_hi_32 = ((bitmap_hi >> 32) & 0xFFFF) as u32;
+        let bm_hi_48 = ((bitmap_hi >> 48) & 0xFFFF) as u32;
+
+        // Non-ASCII path: call helper function
+        // Note: contains() already handles negation internally, so we just check if result is false
+        dynasm!(self.asm
+            ; .arch aarch64
+            // Load cpclass pointer into x1
+            ; movz x1, #cls_lo
+            ; movk x1, #cls_16, lsl #16
+            ; movk x1, #cls_32, lsl #32
+            ; movk x1, #cls_48, lsl #48
+            // Load function pointer into x9
+            ; movz x9, #fn_lo
+            ; movk x9, #fn_16, lsl #16
+            ; movk x9, #fn_32, lsl #32
+            ; movk x9, #fn_48, lsl #48
+            ; blr x9
+            ; cbz w0, =>fail_label
+            ; b =>check_done
+        );
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>ascii_fast
+            ; cmp w0, 64
+            ; b.hs >use_hi
+            // Load bitmap_lo into x2
+            ; movz x2, #bm_lo_0
+            ; movk x2, #bm_lo_16, lsl #16
+            ; movk x2, #bm_lo_32, lsl #32
+            ; movk x2, #bm_lo_48, lsl #48
+            ; mov x3, 1
+            ; lsl x3, x3, x0
+            ; tst x2, x3
+            ; b >check_result
+            ; use_hi:
+            // Load bitmap_hi into x2
+            ; movz x2, #bm_hi_0
+            ; movk x2, #bm_hi_16, lsl #16
+            ; movk x2, #bm_hi_32, lsl #32
+            ; movk x2, #bm_hi_48, lsl #48
+            ; sub w4, w0, 64
+            ; mov x3, 1
+            ; lsl x3, x3, x4
+            ; tst x2, x3
+            ; check_result:
+        );
+
+        if is_negated {
+            dynasm!(self.asm ; .arch aarch64 ; b.ne =>fail_label);
+        } else {
+            dynasm!(self.asm ; .arch aarch64 ; b.eq =>fail_label);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; =>check_done);
+        Ok(())
+    }
+
+    fn emit_codepoint_class_check(&mut self, cpclass: &CodepointClass, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let fail_stack = self.asm.new_dynamic_label();
+        self.emit_utf8_decode(fail_label)?;
+        dynasm!(self.asm ; .arch aarch64 ; str x1, [sp, -16]!);
+        self.emit_codepoint_class_membership_check(cpclass, fail_stack)?;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; ldr x1, [sp], 16
+            ; add x22, x22, x1
+            ; b >done
+            ; =>fail_stack
+            ; add sp, sp, 16
+            ; b =>fail_label
+            ; done:
+        );
+        Ok(())
+    }
+
+    fn emit_greedy_codepoint_plus(&mut self, cpclass: &CodepointClass, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let loop_start = self.asm.new_dynamic_label();
+        let loop_done = self.asm.new_dynamic_label();
+        let first_fail_stack = self.asm.new_dynamic_label();
+        let loop_fail_no_stack = self.asm.new_dynamic_label();
+        let loop_fail_stack = self.asm.new_dynamic_label();
+
+        self.emit_utf8_decode(fail_label)?;
+        dynasm!(self.asm ; .arch aarch64 ; str x1, [sp, -16]!);
+        self.emit_codepoint_class_membership_check(cpclass, first_fail_stack)?;
+        dynasm!(self.asm ; .arch aarch64 ; ldr x1, [sp], 16 ; add x22, x22, x1);
+        dynasm!(self.asm ; .arch aarch64 ; =>loop_start);
+        self.emit_utf8_decode(loop_fail_no_stack)?;
+        dynasm!(self.asm ; .arch aarch64 ; str x1, [sp, -16]!);
+        self.emit_codepoint_class_membership_check(cpclass, loop_fail_stack)?;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; ldr x1, [sp], 16
+            ; add x22, x22, x1
+            ; b =>loop_start
+            ; =>first_fail_stack
+            ; add sp, sp, 16
+            ; b =>fail_label
+            ; =>loop_fail_no_stack
+            ; b =>loop_done
+            ; =>loop_fail_stack
+            ; add sp, sp, 16
+            ; =>loop_done
+        );
+        Ok(())
+    }
+
+    fn emit_non_greedy_suffix_check(&mut self, suffix: &PatternStep, fail_label: dynasmrt::DynamicLabel, _success: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        match suffix {
+            PatternStep::Byte(b) => {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp x22, x20
+                    ; b.ge =>fail_label
+                    ; ldrb w0, [x19, x22]
+                    ; cmp w0, *b as u32
+                    ; b.ne =>fail_label
+                    ; add x22, x22, 1
+                );
+            }
+            PatternStep::ByteClass(bc) => {
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+            }
+            _ => return Err(Error::new(ErrorKind::Jit("Unsupported suffix".to_string()), "")),
+        }
+        Ok(())
+    }
+
+    fn emit_step_inline(&mut self, step: &PatternStep, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        match step {
+            PatternStep::Byte(b) => {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp x22, x20 ; b.ge =>fail_label
+                    ; ldrb w0, [x19, x22]
+                    ; cmp w0, *b as u32 ; b.ne =>fail_label
+                    ; add x22, x22, 1
+                );
+            }
+            PatternStep::ByteClass(bc) => {
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+            }
+            PatternStep::GreedyPlus(bc) => {
+                let ls = self.asm.new_dynamic_label();
+                let ld = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; add x22, x22, 1
+                    ; =>ls ; cmp x22, x20 ; b.ge =>ld ; ldrb w0, [x19, x22]
+                );
+                self.emit_range_check(&bc.ranges, ld)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
+            }
+            PatternStep::GreedyStar(bc) => {
+                let ls = self.asm.new_dynamic_label();
+                let ld = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; =>ls ; cmp x22, x20 ; b.ge =>ld ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, ld)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
+            }
+            PatternStep::CodepointClass(cp, _) => self.emit_codepoint_class_check(cp, fail_label)?,
+            PatternStep::GreedyCodepointPlus(cp) => self.emit_greedy_codepoint_plus(cp, fail_label)?,
+            PatternStep::WordBoundary => self.emit_word_boundary_check(fail_label, true)?,
+            PatternStep::NotWordBoundary => self.emit_word_boundary_check(fail_label, false)?,
+            PatternStep::StartOfText => { dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>fail_label); }
+            PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>fail_label); }
+            PatternStep::StartOfLine => {
+                let at_start = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cbz x22, =>at_start
+                    ; sub x1, x22, 1 ; ldrb w0, [x19, x1] ; cmp w0, 0x0A ; b.ne =>fail_label
+                    ; =>at_start
+                );
+            }
+            PatternStep::EndOfLine => {
+                let at_end = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp x22, x20 ; b.eq =>at_end
+                    ; ldrb w0, [x19, x22] ; cmp w0, 0x0A ; b.ne =>fail_label
+                    ; =>at_end
+                );
+            }
+            PatternStep::CaptureStart(_) | PatternStep::CaptureEnd(_) => {}
+            PatternStep::Alt(alts) => {
+                let success = self.asm.new_dynamic_label();
+                for (i, alt_steps) in alts.iter().enumerate() {
+                    let is_last = i == alts.len() - 1;
+                    let try_next = self.asm.new_dynamic_label();
+                    dynasm!(self.asm ; .arch aarch64 ; str x22, [sp, -16]!);
+                    for s in alt_steps {
+                        self.emit_step_inline(s, try_next)?;
+                    }
+                    dynasm!(self.asm ; .arch aarch64 ; add sp, sp, 16 ; b =>success);
+                    dynasm!(self.asm ; .arch aarch64 ; =>try_next ; ldr x22, [sp], 16);
+                    if is_last {
+                        dynasm!(self.asm ; .arch aarch64 ; b =>fail_label);
+                    }
+                }
+                dynasm!(self.asm ; .arch aarch64 ; =>success);
+            }
+            _ => return Err(Error::new(ErrorKind::Jit(format!("Unsupported step: {:?}", step)), "")),
+        }
+        Ok(())
+    }
+
+    fn emit_standalone_lookahead(&mut self, inner: &[PatternStep], fail_label: dynasmrt::DynamicLabel, positive: bool) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let inner_match = self.asm.new_dynamic_label();
+        dynasm!(self.asm ; .arch aarch64 ; mov x9, x22);  // Save position
+
+        for step in inner {
+            match step {
+                PatternStep::Byte(b) => {
+                    if positive {
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x9] ; cmp w0, *b as u32 ; b.ne =>fail_label ; add x9, x9, 1);
+                    } else {
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ge =>inner_match ; ldrb w0, [x19, x9] ; cmp w0, *b as u32 ; b.ne =>inner_match ; add x9, x9, 1);
+                    }
+                }
+                PatternStep::ByteClass(bc) => {
+                    if positive {
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x9]);
+                        self.emit_range_check(&bc.ranges, fail_label)?;
+                        dynasm!(self.asm ; .arch aarch64 ; add x9, x9, 1);
+                    } else {
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ge =>inner_match ; ldrb w0, [x19, x9]);
+                        self.emit_range_check(&bc.ranges, inner_match)?;
+                        dynasm!(self.asm ; .arch aarch64 ; add x9, x9, 1);
+                    }
+                }
+                PatternStep::EndOfText => {
+                    if positive {
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ne =>fail_label);
+                    } else {
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ne =>inner_match);
+                    }
+                }
+                _ => return Err(Error::new(ErrorKind::Jit("Complex lookahead".to_string()), "")),
+            }
+        }
+
+        if !positive {
+            dynasm!(self.asm ; .arch aarch64 ; b =>fail_label);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; =>inner_match);
+        Ok(())
+    }
+
+    fn emit_lookbehind_check(&mut self, inner: &[PatternStep], min_len: usize, fail_label: dynasmrt::DynamicLabel, positive: bool) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let inner_match = self.asm.new_dynamic_label();
+        let inner_mismatch = self.asm.new_dynamic_label();
+        let done = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm ; .arch aarch64 ; mov x9, x22);
+        if min_len > 0 {
+            dynasm!(self.asm ; .arch aarch64 ; cmp x22, min_len as u32 ; b.lo =>inner_mismatch);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; sub x22, x22, min_len as u32);
+
+        for step in inner {
+            match step {
+                PatternStep::Byte(b) => {
+                    dynasm!(self.asm ; .arch aarch64 ; ldrb w0, [x19, x22] ; cmp w0, *b as u32 ; b.ne =>inner_mismatch ; add x22, x22, 1);
+                }
+                PatternStep::ByteClass(bc) => {
+                    dynasm!(self.asm ; .arch aarch64 ; ldrb w0, [x19, x22]);
+                    self.emit_range_check(&bc.ranges, inner_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+                }
+                _ => return Err(Error::new(ErrorKind::Jit("Unsupported lookbehind step".to_string()), "")),
+            }
+        }
+        dynasm!(self.asm ; .arch aarch64 ; b =>inner_match);
+        dynasm!(self.asm ; .arch aarch64 ; =>inner_mismatch);
+        if positive {
+            dynasm!(self.asm ; .arch aarch64 ; mov x22, x9 ; b =>fail_label);
+            dynasm!(self.asm ; .arch aarch64 ; =>inner_match ; mov x22, x9 ; b =>done);
+        } else {
+            dynasm!(self.asm ; .arch aarch64 ; mov x22, x9 ; b =>done);
+            dynasm!(self.asm ; .arch aarch64 ; =>inner_match ; mov x22, x9 ; b =>fail_label);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; =>done);
+        Ok(())
+    }
+
+    fn compile_full(mut self) -> Result<TaggedNfaJit> {
+        use dynasmrt::DynasmLabelApi;
+        let steps = self.extract_pattern_steps();
+        let steps = Self::combine_greedy_with_lookahead(steps);
+        if steps.is_empty() { return self.compile_with_fallback(None); }
+        for step in &steps {
+            if let PatternStep::Alt(alts) = step {
+                if Self::has_unsupported_in_alt(alts) { return self.compile_with_fallback(Some(steps)); }
+            }
+        }
+        let has_backrefs = Self::has_backref(&steps);
+        let min_len = Self::calc_min_len(&steps);
+
+        let find_offset = self.asm.offset();
+        if has_backrefs {
+            dynasm!(self.asm ; .arch aarch64 ; movn x0, 1 ; ret);
+            let caps_off = self.emit_captures_fn(&steps)?;
+            return self.finalize(find_offset, caps_off, true, None);
+        }
+
+        // Prologue
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; stp x29, x30, [sp, -16]!
+            ; mov x29, sp
+            ; stp x19, x20, [sp, -16]!
+            ; stp x21, x22, [sp, -16]!
+            ; stp x23, x24, [sp, -16]!
+            ; mov x19, x0   // input_ptr
+            ; mov x20, x1   // input_len
+            ; mov x21, xzr  // start_pos = 0
+        );
+
+        let start_loop = self.asm.new_dynamic_label();
+        let match_found = self.asm.new_dynamic_label();
+        let no_match = self.asm.new_dynamic_label();
+        let byte_mismatch = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>start_loop
+            ; sub x0, x20, x21
+            ; cmp x0, min_len as u32
+            ; b.lo =>no_match
+            ; mov x22, x21
+        );
+
+        for (si, step) in steps.iter().enumerate() {
+            match step {
+                PatternStep::Byte(b) => {
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; cmp x22, x20 ; b.ge =>byte_mismatch
+                        ; ldrb w0, [x19, x22]
+                        ; cmp w0, *b as u32 ; b.ne =>byte_mismatch
+                        ; add x22, x22, 1
+                    );
+                }
+                PatternStep::ByteClass(bc) => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>byte_mismatch ; ldrb w0, [x19, x22]);
+                    self.emit_range_check(&bc.ranges, byte_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+                }
+                PatternStep::GreedyPlus(bc) => {
+                    let remaining = &steps[si + 1..];
+                    let needs_bt = remaining.iter().any(|s| Self::step_consumes_input(s));
+                    if needs_bt {
+                        self.emit_greedy_plus_with_backtracking(&bc.ranges, remaining, byte_mismatch)?;
+                        break;
+                    } else {
+                        let ls = self.asm.new_dynamic_label();
+                        let ld = self.asm.new_dynamic_label();
+                        dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>byte_mismatch ; ldrb w0, [x19, x22]);
+                        self.emit_range_check(&bc.ranges, byte_mismatch)?;
+                        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; =>ls ; cmp x22, x20 ; b.ge =>ld ; ldrb w0, [x19, x22]);
+                        self.emit_range_check(&bc.ranges, ld)?;
+                        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
+                    }
+                }
+                PatternStep::GreedyStar(bc) => {
+                    let remaining = &steps[si + 1..];
+                    let needs_bt = remaining.iter().any(|s| Self::step_consumes_input(s));
+                    if needs_bt {
+                        self.emit_greedy_star_with_backtracking(&bc.ranges, remaining, byte_mismatch)?;
+                        break;
+                    } else {
+                        let ls = self.asm.new_dynamic_label();
+                        let ld = self.asm.new_dynamic_label();
+                        dynasm!(self.asm ; .arch aarch64 ; =>ls ; cmp x22, x20 ; b.ge =>ld ; ldrb w0, [x19, x22]);
+                        self.emit_range_check(&bc.ranges, ld)?;
+                        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
+                    }
+                }
+                PatternStep::CaptureStart(_) | PatternStep::CaptureEnd(_) => {}
+                PatternStep::CodepointClass(cp, _) => self.emit_codepoint_class_check(cp, byte_mismatch)?,
+                PatternStep::GreedyCodepointPlus(cp) => {
+                    let remaining = &steps[si + 1..];
+                    let needs_bt = remaining.iter().any(|s| Self::step_consumes_input(s));
+                    if needs_bt {
+                        self.emit_greedy_codepoint_plus_with_backtracking(cp, remaining, byte_mismatch)?;
+                        break;
+                    } else {
+                        self.emit_greedy_codepoint_plus(cp, byte_mismatch)?;
+                    }
+                }
+                PatternStep::WordBoundary => self.emit_word_boundary_check(byte_mismatch, true)?,
+                PatternStep::NotWordBoundary => self.emit_word_boundary_check(byte_mismatch, false)?,
+                PatternStep::StartOfText => { dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>byte_mismatch); }
+                PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>byte_mismatch); }
+                PatternStep::StartOfLine => {
+                    let at_start = self.asm.new_dynamic_label();
+                    dynasm!(self.asm ; .arch aarch64 ; cbz x22, =>at_start ; sub x1, x22, 1 ; ldrb w0, [x19, x1] ; cmp w0, 0x0A ; b.ne =>byte_mismatch ; =>at_start);
+                }
+                PatternStep::EndOfLine => {
+                    let at_end = self.asm.new_dynamic_label();
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.eq =>at_end ; ldrb w0, [x19, x22] ; cmp w0, 0x0A ; b.ne =>byte_mismatch ; =>at_end);
+                }
+                PatternStep::PositiveLookahead(inner) => self.emit_standalone_lookahead(inner, byte_mismatch, true)?,
+                PatternStep::NegativeLookahead(inner) => self.emit_standalone_lookahead(inner, byte_mismatch, false)?,
+                PatternStep::PositiveLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, byte_mismatch, true)?,
+                PatternStep::NegativeLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, byte_mismatch, false)?,
+                PatternStep::Alt(alts) => {
+                    if Self::has_unsupported_in_alt(alts) { return self.compile_with_fallback(Some(steps.clone())); }
+                    let alt_success = self.asm.new_dynamic_label();
+                    dynasm!(self.asm ; .arch aarch64 ; mov x23, x22);
+                    for (ai, alt_steps) in alts.iter().enumerate() {
+                        let is_last = ai == alts.len() - 1;
+                        let try_next = if is_last { byte_mismatch } else { self.asm.new_dynamic_label() };
+                        for s in alt_steps { self.emit_alt_step(s, try_next)?; }
+                        dynasm!(self.asm ; .arch aarch64 ; b =>alt_success);
+                        if !is_last { dynasm!(self.asm ; .arch aarch64 ; =>try_next ; mov x22, x23); }
+                    }
+                    dynasm!(self.asm ; .arch aarch64 ; =>alt_success);
+                }
+                PatternStep::NonGreedyPlus(bc, suf) => {
+                    let try_suf = self.asm.new_dynamic_label();
+                    let consume = self.asm.new_dynamic_label();
+                    let matched = self.asm.new_dynamic_label();
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>byte_mismatch ; ldrb w0, [x19, x22]);
+                    self.emit_range_check(&bc.ranges, byte_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; =>try_suf);
+                    self.emit_non_greedy_suffix_check(suf, consume, matched)?;
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; b =>matched
+                        ; =>consume
+                        ; cmp x22, x20 ; b.ge =>byte_mismatch ; ldrb w0, [x19, x22]
+                    );
+                    self.emit_range_check(&bc.ranges, byte_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>try_suf ; =>matched);
+                }
+                PatternStep::NonGreedyStar(bc, suf) => {
+                    let try_suf = self.asm.new_dynamic_label();
+                    let consume = self.asm.new_dynamic_label();
+                    let matched = self.asm.new_dynamic_label();
+                    dynasm!(self.asm ; .arch aarch64 ; =>try_suf);
+                    self.emit_non_greedy_suffix_check(suf, consume, matched)?;
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; b =>matched
+                        ; =>consume
+                        ; cmp x22, x20 ; b.ge =>byte_mismatch ; ldrb w0, [x19, x22]
+                    );
+                    self.emit_range_check(&bc.ranges, byte_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>try_suf ; =>matched);
+                }
+                PatternStep::GreedyPlusLookahead(bc, la, pos) => self.emit_greedy_plus_with_lookahead(&bc.ranges, la, *pos, byte_mismatch)?,
+                PatternStep::GreedyStarLookahead(bc, la, pos) => self.emit_greedy_star_with_lookahead(&bc.ranges, la, *pos, byte_mismatch)?,
+                PatternStep::Backref(_) => unreachable!("Backref handled above"),
+            }
+        }
+
+        dynasm!(self.asm ; .arch aarch64 ; b =>match_found);
+        dynasm!(self.asm ; .arch aarch64 ; =>byte_mismatch ; add x21, x21, 1 ; b =>start_loop);
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>match_found
+            ; lsl x0, x21, 32
+            ; orr x0, x0, x22
+            ; ldp x23, x24, [sp], 16
+            ; ldp x21, x22, [sp], 16
+            ; ldp x19, x20, [sp], 16
+            ; ldp x29, x30, [sp], 16
+            ; ret
+        );
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>no_match
+            ; movn x0, 0
+            ; ldp x23, x24, [sp], 16
+            ; ldp x21, x22, [sp], 16
+            ; ldp x19, x20, [sp], 16
+            ; ldp x29, x30, [sp], 16
+            ; ret
+        );
+
+        let has_captures = steps.iter().any(|s| matches!(s, PatternStep::CaptureStart(_) | PatternStep::CaptureEnd(_)));
+        let caps_off = if has_captures { self.emit_captures_fn(&steps)? } else {
+            let off = self.asm.offset();
+            dynasm!(self.asm ; .arch aarch64 ; movn x0, 1 ; ret);
+            off
+        };
+
+        self.finalize(find_offset, caps_off, false, Some(steps))
+    }
+
+    fn emit_alt_step(&mut self, step: &PatternStep, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        self.emit_step_inline(step, fail_label)
+    }
+
+    fn emit_greedy_plus_with_backtracking(&mut self, ranges: &[ByteRange], remaining: &[PatternStep], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let greedy_loop = self.asm.new_dynamic_label();
+        let greedy_done = self.asm.new_dynamic_label();
+        let try_remaining = self.asm.new_dynamic_label();
+        let backtrack = self.asm.new_dynamic_label();
+        let success = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+        self.emit_range_check(ranges, fail_label)?;
+        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; mov x9, x22);
+        dynasm!(self.asm ; .arch aarch64 ; =>greedy_loop ; cmp x22, x20 ; b.ge =>greedy_done ; ldrb w0, [x19, x22]);
+        self.emit_range_check(ranges, greedy_done)?;
+        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>greedy_loop ; =>greedy_done ; =>try_remaining);
+        for s in remaining { self.emit_step_inline(s, backtrack)?; }
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; b =>success
+            ; =>backtrack ; sub x22, x22, 1 ; cmp x22, x9 ; b.lo =>fail_label ; b =>try_remaining
+            ; =>success
+        );
+        Ok(())
+    }
+
+    fn emit_greedy_star_with_backtracking(&mut self, ranges: &[ByteRange], remaining: &[PatternStep], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let greedy_loop = self.asm.new_dynamic_label();
+        let greedy_done = self.asm.new_dynamic_label();
+        let try_remaining = self.asm.new_dynamic_label();
+        let backtrack = self.asm.new_dynamic_label();
+        let success = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm ; .arch aarch64 ; mov x9, x22);
+        dynasm!(self.asm ; .arch aarch64 ; =>greedy_loop ; cmp x22, x20 ; b.ge =>greedy_done ; ldrb w0, [x19, x22]);
+        self.emit_range_check(ranges, greedy_done)?;
+        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>greedy_loop ; =>greedy_done ; =>try_remaining);
+        for s in remaining { self.emit_step_inline(s, backtrack)?; }
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; b =>success
+            ; =>backtrack ; cmp x22, x9 ; b.ls =>fail_label ; sub x22, x22, 1 ; b =>try_remaining
+            ; =>success
+        );
+        Ok(())
+    }
+
+    fn emit_greedy_codepoint_plus_with_backtracking(&mut self, cpclass: &CodepointClass, remaining: &[PatternStep], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        // Simplified: use normal greedy then try remaining
+        self.emit_greedy_codepoint_plus(cpclass, fail_label)?;
+        for s in remaining { self.emit_step_inline(s, fail_label)?; }
+        Ok(())
+    }
+
+    fn emit_greedy_plus_with_lookahead(&mut self, ranges: &[ByteRange], la_steps: &[PatternStep], positive: bool, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let greedy_loop = self.asm.new_dynamic_label();
+        let greedy_done = self.asm.new_dynamic_label();
+        let try_la = self.asm.new_dynamic_label();
+        let la_failed = self.asm.new_dynamic_label();
+        let success = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+        self.emit_range_check(ranges, fail_label)?;
+        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; mov x9, x22);
+        dynasm!(self.asm ; .arch aarch64 ; =>greedy_loop ; cmp x22, x20 ; b.ge =>greedy_done ; ldrb w0, [x19, x22]);
+        self.emit_range_check(ranges, greedy_done)?;
+        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>greedy_loop ; =>greedy_done ; =>try_la ; mov x10, x22);
+
+        let la_match = self.asm.new_dynamic_label();
+        let la_mismatch = self.asm.new_dynamic_label();
+        for step in la_steps {
+            match step {
+                PatternStep::Byte(b) => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>la_mismatch ; ldrb w0, [x19, x22] ; cmp w0, *b as u32 ; b.ne =>la_mismatch ; add x22, x22, 1);
+                }
+                PatternStep::ByteClass(bc) => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>la_mismatch ; ldrb w0, [x19, x22]);
+                    self.emit_range_check(&bc.ranges, la_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+                }
+                PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>la_mismatch); }
+                _ => {}
+            }
+        }
+        dynasm!(self.asm ; .arch aarch64 ; b =>la_match ; =>la_mismatch);
+        if positive {
+            dynasm!(self.asm ; .arch aarch64 ; mov x22, x10 ; b =>la_failed ; =>la_match ; mov x22, x10 ; b =>success);
+        } else {
+            dynasm!(self.asm ; .arch aarch64 ; mov x22, x10 ; b =>success ; =>la_match ; mov x22, x10 ; b =>la_failed);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; =>la_failed ; sub x22, x22, 1 ; cmp x22, x9 ; b.lo =>fail_label ; b =>try_la ; =>success);
+        Ok(())
+    }
+
+    fn emit_greedy_star_with_lookahead(&mut self, ranges: &[ByteRange], la_steps: &[PatternStep], positive: bool, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        let greedy_loop = self.asm.new_dynamic_label();
+        let greedy_done = self.asm.new_dynamic_label();
+        let try_la = self.asm.new_dynamic_label();
+        let la_failed = self.asm.new_dynamic_label();
+        let success = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm ; .arch aarch64 ; mov x9, x22);
+        dynasm!(self.asm ; .arch aarch64 ; =>greedy_loop ; cmp x22, x20 ; b.ge =>greedy_done ; ldrb w0, [x19, x22]);
+        self.emit_range_check(ranges, greedy_done)?;
+        dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>greedy_loop ; =>greedy_done ; =>try_la ; mov x10, x22);
+
+        let la_match = self.asm.new_dynamic_label();
+        let la_mismatch = self.asm.new_dynamic_label();
+        for step in la_steps {
+            match step {
+                PatternStep::Byte(b) => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>la_mismatch ; ldrb w0, [x19, x22] ; cmp w0, *b as u32 ; b.ne =>la_mismatch ; add x22, x22, 1);
+                }
+                PatternStep::ByteClass(bc) => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>la_mismatch ; ldrb w0, [x19, x22]);
+                    self.emit_range_check(&bc.ranges, la_mismatch)?;
+                    dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+                }
+                PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>la_mismatch); }
+                _ => {}
+            }
+        }
+        dynasm!(self.asm ; .arch aarch64 ; b =>la_match ; =>la_mismatch);
+        if positive {
+            dynasm!(self.asm ; .arch aarch64 ; mov x22, x10 ; b =>la_failed ; =>la_match ; mov x22, x10 ; b =>success);
+        } else {
+            dynasm!(self.asm ; .arch aarch64 ; mov x22, x10 ; b =>success ; =>la_match ; mov x22, x10 ; b =>la_failed);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; =>la_failed ; cmp x22, x9 ; b.ls =>fail_label ; sub x22, x22, 1 ; b =>try_la ; =>success);
+        Ok(())
+    }
+
+    fn emit_captures_fn(&mut self, steps: &[PatternStep]) -> Result<dynasmrt::AssemblyOffset> {
+        use dynasmrt::DynasmLabelApi;
+        let offset = self.asm.offset();
+        let min_len = Self::calc_min_len(steps);
+        let max_cap_idx = steps.iter().filter_map(|s| match s {
+            PatternStep::CaptureStart(i) | PatternStep::CaptureEnd(i) => Some(*i),
+            _ => None,
+        }).max().unwrap_or(0);
+        let num_slots = (max_cap_idx as usize + 1) * 2;
+
+        // Prologue: x0=input, x1=len, x2=ctx, x3=captures
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; stp x29, x30, [sp, -16]!
+            ; mov x29, sp
+            ; stp x19, x20, [sp, -16]!
+            ; stp x21, x22, [sp, -16]!
+            ; stp x23, x24, [sp, -16]!
+            ; mov x19, x0
+            ; mov x20, x1
+            ; mov x23, x3  // captures ptr
+            ; mov x21, xzr
+        );
+
+        // Init captures to -1
+        for slot in 0..num_slots {
+            let off = (slot * 8) as u32;
+            dynasm!(self.asm ; .arch aarch64 ; movn x0, 0 ; str x0, [x23, off]);
+        }
+
+        let start_loop = self.asm.new_dynamic_label();
+        let match_found = self.asm.new_dynamic_label();
+        let no_match = self.asm.new_dynamic_label();
+        let byte_mismatch = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>start_loop
+            ; sub x0, x20, x21
+            ; cmp x0, min_len as u32
+            ; b.lo =>no_match
+            ; mov x22, x21
+            ; str x21, [x23]  // group 0 start
+        );
+
+        for step in steps {
+            self.emit_capture_step(step, byte_mismatch, num_slots)?;
+        }
+
+        dynasm!(self.asm ; .arch aarch64 ; b =>match_found);
+        dynasm!(self.asm ; .arch aarch64 ; =>byte_mismatch);
+        for slot in 0..num_slots {
+            let off = (slot * 8) as u32;
+            dynasm!(self.asm ; .arch aarch64 ; movn x0, 0 ; str x0, [x23, off]);
+        }
+        dynasm!(self.asm ; .arch aarch64 ; add x21, x21, 1 ; b =>start_loop);
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>match_found
+            ; str x22, [x23, 8]  // group 0 end
+            ; lsl x0, x21, 32
+            ; orr x0, x0, x22
+            ; ldp x23, x24, [sp], 16
+            ; ldp x21, x22, [sp], 16
+            ; ldp x19, x20, [sp], 16
+            ; ldp x29, x30, [sp], 16
+            ; ret
+        );
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>no_match
+            ; movn x0, 0
+            ; ldp x23, x24, [sp], 16
+            ; ldp x21, x22, [sp], 16
+            ; ldp x19, x20, [sp], 16
+            ; ldp x29, x30, [sp], 16
+            ; ret
+        );
+        Ok(offset)
+    }
+
+    fn emit_capture_step(&mut self, step: &PatternStep, fail_label: dynasmrt::DynamicLabel, _num_slots: usize) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+        match step {
+            PatternStep::Byte(b) => {
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22] ; cmp w0, *b as u32 ; b.ne =>fail_label ; add x22, x22, 1);
+            }
+            PatternStep::ByteClass(bc) => {
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
+            }
+            PatternStep::GreedyPlus(bc) => {
+                let ls = self.asm.new_dynamic_label();
+                let ld = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; =>ls ; cmp x22, x20 ; b.ge =>ld ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, ld)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
+            }
+            PatternStep::GreedyStar(bc) => {
+                let ls = self.asm.new_dynamic_label();
+                let ld = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; =>ls ; cmp x22, x20 ; b.ge =>ld ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, ld)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
+            }
+            PatternStep::CaptureStart(idx) => {
+                let off = ((*idx as usize) * 2 * 8) as u32;
+                dynasm!(self.asm ; .arch aarch64 ; str x22, [x23, off]);
+            }
+            PatternStep::CaptureEnd(idx) => {
+                let off = ((*idx as usize) * 2 * 8 + 8) as u32;
+                dynasm!(self.asm ; .arch aarch64 ; str x22, [x23, off]);
+            }
+            PatternStep::Alt(alts) => {
+                let success = self.asm.new_dynamic_label();
+                let alt_fail = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; str x22, [sp, -16]!);
+                for (ai, alt_steps) in alts.iter().enumerate() {
+                    let is_last = ai == alts.len() - 1;
+                    let try_next = if is_last { alt_fail } else { self.asm.new_dynamic_label() };
+                    for s in alt_steps { self.emit_capture_step(s, try_next, _num_slots)?; }
+                    dynasm!(self.asm ; .arch aarch64 ; add sp, sp, 16 ; b =>success);
+                    if !is_last { dynasm!(self.asm ; .arch aarch64 ; =>try_next ; ldr x22, [sp]); }
+                }
+                dynasm!(self.asm ; .arch aarch64 ; =>alt_fail ; add sp, sp, 16 ; b =>fail_label);
+                dynasm!(self.asm ; .arch aarch64 ; =>success);
+            }
+            PatternStep::CodepointClass(cp, _) => self.emit_codepoint_class_check(cp, fail_label)?,
+            PatternStep::GreedyCodepointPlus(cp) => self.emit_greedy_codepoint_plus(cp, fail_label)?,
+            PatternStep::WordBoundary => self.emit_word_boundary_check(fail_label, true)?,
+            PatternStep::NotWordBoundary => self.emit_word_boundary_check(fail_label, false)?,
+            PatternStep::PositiveLookahead(inner) => self.emit_standalone_lookahead(inner, fail_label, true)?,
+            PatternStep::NegativeLookahead(inner) => self.emit_standalone_lookahead(inner, fail_label, false)?,
+            PatternStep::PositiveLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, fail_label, true)?,
+            PatternStep::NegativeLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, fail_label, false)?,
+            PatternStep::StartOfText => { dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>fail_label); }
+            PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>fail_label); }
+            PatternStep::StartOfLine => {
+                let at_start = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; cbz x22, =>at_start ; sub x1, x22, 1 ; ldrb w0, [x19, x1] ; cmp w0, 0x0A ; b.ne =>fail_label ; =>at_start);
+            }
+            PatternStep::EndOfLine => {
+                let at_end = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.eq =>at_end ; ldrb w0, [x19, x22] ; cmp w0, 0x0A ; b.ne =>fail_label ; =>at_end);
+            }
+            PatternStep::Backref(idx) => {
+                let idx = *idx as usize;
+                let start_off = (idx * 2 * 8) as u32;
+                let end_off = (idx * 2 * 8 + 8) as u32;
+                let backref_match = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; ldr x8, [x23, start_off]
+                    ; ldr x9, [x23, end_off]
+                    ; tst x8, x8
+                    ; b.mi =>fail_label
+                    ; tst x9, x9
+                    ; b.mi =>fail_label
+                    ; sub x10, x9, x8  // cap_len
+                    ; cbz x10, =>backref_match
+                    ; add x0, x22, x10
+                    ; cmp x0, x20
+                    ; b.hi =>fail_label
+                );
+                // Compare bytes
+                let cmp_loop = self.asm.new_dynamic_label();
+                let cmp_done = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; mov x11, x8   // cap_start
+                    ; mov x12, x22  // current
+                    ; =>cmp_loop
+                    ; cmp x11, x9
+                    ; b.ge =>cmp_done
+                    ; ldrb w0, [x19, x11]
+                    ; ldrb w1, [x19, x12]
+                    ; cmp w0, w1
+                    ; b.ne =>fail_label
+                    ; add x11, x11, 1
+                    ; add x12, x12, 1
+                    ; b =>cmp_loop
+                    ; =>cmp_done
+                    ; add x22, x22, x10
+                    ; =>backref_match
+                );
+            }
+            PatternStep::NonGreedyPlus(bc, suf) => {
+                let try_suf = self.asm.new_dynamic_label();
+                let consume = self.asm.new_dynamic_label();
+                let matched = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; =>try_suf);
+                self.emit_non_greedy_suffix_check(suf, consume, matched)?;
+                dynasm!(self.asm ; .arch aarch64 ; b =>matched ; =>consume ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>try_suf ; =>matched);
+            }
+            PatternStep::NonGreedyStar(bc, suf) => {
+                let try_suf = self.asm.new_dynamic_label();
+                let consume = self.asm.new_dynamic_label();
+                let matched = self.asm.new_dynamic_label();
+                dynasm!(self.asm ; .arch aarch64 ; =>try_suf);
+                self.emit_non_greedy_suffix_check(suf, consume, matched)?;
+                dynasm!(self.asm ; .arch aarch64 ; b =>matched ; =>consume ; cmp x22, x20 ; b.ge =>fail_label ; ldrb w0, [x19, x22]);
+                self.emit_range_check(&bc.ranges, fail_label)?;
+                dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>try_suf ; =>matched);
+            }
+            PatternStep::GreedyPlusLookahead(bc, la, pos) => self.emit_greedy_plus_with_lookahead(&bc.ranges, la, *pos, fail_label)?,
+            PatternStep::GreedyStarLookahead(bc, la, pos) => self.emit_greedy_star_with_lookahead(&bc.ranges, la, *pos, fail_label)?,
+        }
+        Ok(())
+    }
+
+    fn extract_pattern_steps(&self) -> Vec<PatternStep> {
+        let mut visited = vec![false; self.nfa.states.len()];
+        self.extract_from_state(self.nfa.start, &mut visited, None)
+    }
+
+    fn extract_from_state(&self, start: StateId, visited: &mut [bool], end_state: Option<StateId>) -> Vec<PatternStep> {
+        let mut steps = Vec::new();
+        let mut current = start;
+        loop {
+            if let Some(end) = end_state { if current == end { break; } }
+            let state = &self.nfa.states[current as usize];
+            if let Some(ref instr) = state.instruction {
+                match instr {
+                    NfaInstruction::CaptureStart(i) => steps.push(PatternStep::CaptureStart(*i)),
+                    NfaInstruction::CaptureEnd(i) => steps.push(PatternStep::CaptureEnd(*i)),
+                    NfaInstruction::CodepointClass(cp, t) => {
+                        let ts = &self.nfa.states[*t as usize];
+                        if ts.epsilon.len() == 2 && ts.transitions.is_empty() {
+                            let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
+                            if e0 == current {
+                                steps.push(PatternStep::GreedyCodepointPlus(cp.clone()));
+                                visited[current as usize] = true; visited[*t as usize] = true;
+                                current = e1; continue;
+                            } else if e1 == current {
+                                steps.push(PatternStep::GreedyCodepointPlus(cp.clone()));
+                                visited[current as usize] = true; visited[*t as usize] = true;
+                                current = e0; continue;
+                            }
+                        }
+                        steps.push(PatternStep::CodepointClass(cp.clone(), *t));
+                        current = *t; continue;
+                    }
+                    NfaInstruction::Backref(i) => {
+                        steps.push(PatternStep::Backref(*i));
+                        if state.epsilon.len() == 1 {
+                            visited[current as usize] = true; current = state.epsilon[0]; continue;
+                        } else if state.epsilon.is_empty() && state.is_match { break; }
+                        else { return Vec::new(); }
+                    }
+                    NfaInstruction::PositiveLookahead(inner) => {
+                        let inner_steps = self.extract_lookaround_steps(inner);
+                        if inner_steps.is_empty() { return Vec::new(); }
+                        steps.push(PatternStep::PositiveLookahead(inner_steps));
+                    }
+                    NfaInstruction::NegativeLookahead(inner) => {
+                        let inner_steps = self.extract_lookaround_steps(inner);
+                        if inner_steps.is_empty() { return Vec::new(); }
+                        steps.push(PatternStep::NegativeLookahead(inner_steps));
+                    }
+                    NfaInstruction::PositiveLookbehind(inner) => {
+                        let inner_steps = self.extract_lookaround_steps(inner);
+                        if inner_steps.is_empty() { return Vec::new(); }
+                        let ml = Self::calc_min_len(&inner_steps);
+                        steps.push(PatternStep::PositiveLookbehind(inner_steps, ml));
+                    }
+                    NfaInstruction::NegativeLookbehind(inner) => {
+                        let inner_steps = self.extract_lookaround_steps(inner);
+                        if inner_steps.is_empty() { return Vec::new(); }
+                        let ml = Self::calc_min_len(&inner_steps);
+                        steps.push(PatternStep::NegativeLookbehind(inner_steps, ml));
+                    }
+                    NfaInstruction::WordBoundary => steps.push(PatternStep::WordBoundary),
+                    NfaInstruction::NotWordBoundary => steps.push(PatternStep::NotWordBoundary),
+                    NfaInstruction::StartOfText => steps.push(PatternStep::StartOfText),
+                    NfaInstruction::EndOfText => steps.push(PatternStep::EndOfText),
+                    NfaInstruction::StartOfLine => steps.push(PatternStep::StartOfLine),
+                    NfaInstruction::EndOfLine => steps.push(PatternStep::EndOfLine),
+                    NfaInstruction::NonGreedyExit => {}
+                }
+            }
+            if state.is_match { break; }
+            if !state.transitions.is_empty() {
+                let target = state.transitions[0].1;
+                if !state.transitions.iter().all(|(_, t)| *t == target) { return Vec::new(); }
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ts = &self.nfa.states[target as usize];
+                if ts.epsilon.len() == 2 && ts.transitions.is_empty() {
+                    let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
+                    if e0 == current {
+                        steps.push(PatternStep::GreedyPlus(ByteClass::new(ranges)));
+                        current = e1; visited[target as usize] = true; continue;
+                    }
+                    let ms = &self.nfa.states[e0 as usize];
+                    if e1 == current && ms.transitions.is_empty() && ms.epsilon.len() == 1 && matches!(ms.instruction, Some(NfaInstruction::NonGreedyExit)) {
+                        let exit = ms.epsilon[0];
+                        if let Some(suf) = self.extract_single_step(exit) {
+                            steps.push(PatternStep::NonGreedyPlus(ByteClass::new(ranges), Box::new(suf)));
+                            visited[target as usize] = true; visited[e0 as usize] = true; visited[exit as usize] = true;
+                            current = self.advance_past_step(exit); continue;
+                        }
+                        return Vec::new();
+                    }
+                }
+                if visited[current as usize] { return Vec::new(); }
+                visited[current as usize] = true;
+                if ranges.len() == 1 && ranges[0].start == ranges[0].end {
+                    steps.push(PatternStep::Byte(ranges[0].start));
+                } else {
+                    steps.push(PatternStep::ByteClass(ByteClass::new(ranges)));
+                }
+                current = target; continue;
+            }
+            if state.epsilon.len() == 1 && state.transitions.is_empty() {
+                if visited[current as usize] { return Vec::new(); }
+                visited[current as usize] = true;
+                current = state.epsilon[0]; continue;
+            }
+            if state.epsilon.len() > 1 && state.transitions.is_empty() {
+                if state.epsilon.len() == 2 {
+                    let e0s = &self.nfa.states[state.epsilon[0] as usize];
+                    if e0s.transitions.is_empty() && e0s.epsilon.len() == 1 && matches!(e0s.instruction, Some(NfaInstruction::NonGreedyExit)) {
+                        let ps = state.epsilon[1];
+                        let pst = &self.nfa.states[ps as usize];
+                        if !pst.transitions.is_empty() {
+                            let t = pst.transitions[0].1;
+                            if pst.transitions.iter().all(|(_, tt)| *tt == t) {
+                                let ranges: Vec<ByteRange> = pst.transitions.iter().map(|(r, _)| r.clone()).collect();
+                                let exit = e0s.epsilon[0];
+                                if let Some(suf) = self.extract_single_step(exit) {
+                                    steps.push(PatternStep::NonGreedyStar(ByteClass::new(ranges), Box::new(suf)));
+                                    visited[current as usize] = true; visited[state.epsilon[0] as usize] = true;
+                                    visited[ps as usize] = true; visited[exit as usize] = true;
+                                    current = self.advance_past_step(exit); continue;
+                                }
+                            }
+                        }
+                        return Vec::new();
+                    }
+                }
+                let common_end = self.find_alternation_end(current);
+                if common_end.is_none() { return Vec::new(); }
+                let ce = common_end.unwrap();
+                let mut alts = Vec::new();
+                for &alt_start in &state.epsilon {
+                    let mut av = visited.to_vec();
+                    let alt_steps = self.extract_from_state(alt_start, &mut av, Some(ce));
+                    if alt_steps.is_empty() && !self.is_trivial_path(alt_start, ce) { return Vec::new(); }
+                    alts.push(alt_steps);
+                }
+                steps.push(PatternStep::Alt(alts));
+                visited[current as usize] = true;
+                current = ce; continue;
+            }
+            if state.transitions.is_empty() && state.epsilon.is_empty() { break; }
+            return Vec::new();
+        }
+        steps
+    }
+
+    fn extract_lookaround_steps(&self, inner: &Nfa) -> Vec<PatternStep> {
+        let mut visited = vec![false; inner.states.len()];
+        let mut steps = Vec::new();
+        let mut current = inner.start;
+        loop {
+            if current as usize >= inner.states.len() { return Vec::new(); }
+            let state = &inner.states[current as usize];
+            if state.is_match { break; }
+            if let Some(ref instr) = state.instruction {
+                match instr {
+                    NfaInstruction::WordBoundary => steps.push(PatternStep::WordBoundary),
+                    NfaInstruction::EndOfText => steps.push(PatternStep::EndOfText),
+                    NfaInstruction::StartOfText => steps.push(PatternStep::StartOfText),
+                    _ => return Vec::new(),
+                }
+            }
+            if !state.transitions.is_empty() {
+                let t = state.transitions[0].1;
+                if !state.transitions.iter().all(|(_, tt)| *tt == t) { return Vec::new(); }
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ts = &inner.states[t as usize];
+                if ts.transitions.is_empty() && ts.epsilon.len() == 2 {
+                    let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
+                    if e0 == current {
+                        steps.push(PatternStep::GreedyPlus(ByteClass::new(ranges)));
+                        if visited[t as usize] { return Vec::new(); }
+                        visited[t as usize] = true; current = e1; continue;
+                    } else if e1 == current {
+                        steps.push(PatternStep::GreedyPlus(ByteClass::new(ranges)));
+                        if visited[t as usize] { return Vec::new(); }
+                        visited[t as usize] = true; current = e0; continue;
+                    }
+                }
+                if visited[current as usize] { return Vec::new(); }
+                visited[current as usize] = true;
+                if ranges.len() == 1 && ranges[0].start == ranges[0].end {
+                    steps.push(PatternStep::Byte(ranges[0].start));
+                } else {
+                    steps.push(PatternStep::ByteClass(ByteClass::new(ranges)));
+                }
+                current = t; continue;
+            }
+            if state.epsilon.len() == 1 && state.transitions.is_empty() {
+                if visited[current as usize] { return Vec::new(); }
+                visited[current as usize] = true;
+                current = state.epsilon[0]; continue;
+            }
+            if state.epsilon.len() == 2 && state.transitions.is_empty() {
+                let (e0, e1) = (state.epsilon[0], state.epsilon[1]);
+                if let Some((r, exit)) = self.detect_greedy_star_lookaround(inner, current, e0, e1, &visited) {
+                    steps.push(PatternStep::GreedyStar(ByteClass::new(r)));
+                    visited[current as usize] = true; current = exit; continue;
+                }
+                if let Some((r, exit)) = self.detect_greedy_star_lookaround(inner, current, e1, e0, &visited) {
+                    steps.push(PatternStep::GreedyStar(ByteClass::new(r)));
+                    visited[current as usize] = true; current = exit; continue;
+                }
+                return Vec::new();
+            }
+            if !state.epsilon.is_empty() || !state.transitions.is_empty() { return Vec::new(); }
+            break;
+        }
+        steps
+    }
+
+    fn detect_greedy_star_lookaround(&self, inner: &Nfa, branch: StateId, loop_start: StateId, exit: StateId, visited: &[bool]) -> Option<(Vec<ByteRange>, StateId)> {
+        if loop_start as usize >= inner.states.len() { return None; }
+        let ls = &inner.states[loop_start as usize];
+        if ls.transitions.is_empty() { return None; }
+        let t = ls.transitions[0].1;
+        if !ls.transitions.iter().all(|(_, tt)| *tt == t) { return None; }
+        let ranges: Vec<ByteRange> = ls.transitions.iter().map(|(r, _)| r.clone()).collect();
+        let ts = &inner.states[t as usize];
+        if ts.epsilon.len() == 1 {
+            let back = ts.epsilon[0];
+            if (back == branch || back == loop_start) && !visited[loop_start as usize] { return Some((ranges, exit)); }
+        }
+        if ts.epsilon.len() == 2 {
+            let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
+            let (back, fwd) = if e0 == branch || e0 == loop_start { (e0, e1) } else if e1 == branch || e1 == loop_start { (e1, e0) } else { return None; };
+            let _ = back;
+            if fwd == exit && !visited[loop_start as usize] { return Some((ranges, exit)); }
+        }
+        None
+    }
+
+    fn find_alternation_end(&self, start: StateId) -> Option<StateId> {
+        self.find_alternation_end_depth(start, 0)
+    }
+
+    fn find_alternation_end_depth(&self, start: StateId, depth: usize) -> Option<StateId> {
+        if depth > 20 { return None; }
+        let state = &self.nfa.states[start as usize];
+        if state.epsilon.len() < 2 { return None; }
+        let mut ends = Vec::new();
+        for &alt_start in &state.epsilon {
+            if let Some(e) = self.trace_to_merge_depth(alt_start, start, depth) { ends.push(e); } else { return None; }
+        }
+        if ends.is_empty() { return None; }
+        let first = ends[0];
+        if ends.iter().all(|&e| e == first) { Some(first) } else { None }
+    }
+
+    fn trace_to_merge_depth(&self, start: StateId, alt_start: StateId, depth: usize) -> Option<StateId> {
+        if depth > 20 { return None; }
+        let mut current = start;
+        let mut visited = vec![false; self.nfa.states.len()];
+        visited[alt_start as usize] = true;
+        for _ in 0..200 {
+            if visited[current as usize] { return None; }
+            visited[current as usize] = true;
+            let state = &self.nfa.states[current as usize];
+            if state.is_match { return Some(current); }
+            if let Some(NfaInstruction::CodepointClass(_, t)) = &state.instruction { current = *t; continue; }
+            if state.transitions.is_empty() && state.epsilon.is_empty() { return Some(current); }
+            if state.epsilon.len() == 1 && state.transitions.is_empty() { current = state.epsilon[0]; continue; }
+            if !state.transitions.is_empty() && state.epsilon.is_empty() { current = state.transitions[0].1; continue; }
+            if !state.transitions.is_empty() && state.epsilon.len() == 1 { current = state.transitions[0].1; continue; }
+            if state.epsilon.len() >= 2 && state.transitions.is_empty() {
+                let mut fwd = Vec::new();
+                for &e in &state.epsilon { if !visited[e as usize] { fwd.push(e); } }
+                if fwd.len() == 1 { current = fwd[0]; continue; }
+                if let Some(ne) = self.find_alternation_end_depth(current, depth + 1) { current = ne; continue; }
+                return None;
+            }
+            return None;
+        }
+        None
+    }
+
+    fn is_trivial_path(&self, start: StateId, end: StateId) -> bool {
+        self.is_trivial_path_depth(start, end, 0)
+    }
+
+    fn is_trivial_path_depth(&self, start: StateId, end: StateId, depth: usize) -> bool {
+        if depth > 100 { return false; }
+        if start == end { return true; }
+        let state = &self.nfa.states[start as usize];
+        if state.epsilon.len() == 1 && state.transitions.is_empty() {
+            return state.epsilon[0] == end || self.is_trivial_path_depth(state.epsilon[0], end, depth + 1);
+        }
+        false
+    }
+
+    fn extract_single_step(&self, state_id: StateId) -> Option<PatternStep> {
+        let mut current = state_id;
+        loop {
+            let state = &self.nfa.states[current as usize];
+            if !state.transitions.is_empty() {
+                let t = state.transitions[0].1;
+                if !state.transitions.iter().all(|(_, tt)| *tt == t) { return None; }
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                return if ranges.len() == 1 && ranges[0].start == ranges[0].end {
+                    Some(PatternStep::Byte(ranges[0].start))
+                } else {
+                    Some(PatternStep::ByteClass(ByteClass::new(ranges)))
+                };
+            }
+            if state.epsilon.len() == 1 && state.transitions.is_empty() { current = state.epsilon[0]; continue; }
+            if state.is_match || state.epsilon.len() > 1 { return None; }
+            return None;
+        }
+    }
+
+    fn advance_past_step(&self, state_id: StateId) -> StateId {
+        let mut current = state_id;
+        loop {
+            let state = &self.nfa.states[current as usize];
+            if !state.transitions.is_empty() { return state.transitions[0].1; }
+            if state.epsilon.len() == 1 { current = state.epsilon[0]; continue; }
+            return current;
+        }
+    }
+
+    fn finalize(self, find_offset: dynasmrt::AssemblyOffset, captures_offset: dynasmrt::AssemblyOffset, find_needs_ctx: bool, fallback_steps: Option<Vec<PatternStep>>) -> Result<TaggedNfaJit> {
+        let code = self.asm.finalize().map_err(|e| Error::new(ErrorKind::Jit(format!("Failed to finalize: {:?}", e)), ""))?;
+        let find_fn: extern "C" fn(*const u8, usize, *mut TaggedNfaContext) -> i64 = unsafe { std::mem::transmute(code.ptr(find_offset)) };
+        let captures_fn: extern "C" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64 = unsafe { std::mem::transmute(code.ptr(captures_offset)) };
+        let capture_count = self.nfa.capture_count;
+        let state_count = self.nfa.states.len();
+        let lookaround_count = self.liveness.lookaround_count;
+        let stride = (capture_count as usize + 1) * 2;
+        Ok(TaggedNfaJit::new(code, find_fn, captures_fn, self.liveness, self.nfa, capture_count, state_count, lookaround_count, stride, self.codepoint_classes, self.lookaround_nfas, find_needs_ctx, fallback_steps))
+    }
+}

--- a/src/nfa/tagged/jit/aarch64.rs
+++ b/src/nfa/tagged/jit/aarch64.rs
@@ -45,8 +45,6 @@ pub(super) struct TaggedNfaJitCompiler {
 impl TaggedNfaJitCompiler {
     #[allow(dead_code)]
     fn new(nfa: Nfa, liveness: NfaLiveness) -> Result<Self> {
-        use dynasmrt::DynasmLabelApi;
-
         let mut asm = dynasmrt::aarch64::Assembler::new().map_err(|e| {
             Error::new(
                 ErrorKind::Jit(format!("Failed to create assembler: {:?}", e)),
@@ -156,22 +154,31 @@ impl TaggedNfaJitCompiler {
             | PatternStep::GreedyPlusLookahead(_, _, _)
             | PatternStep::GreedyStarLookahead(_, _, _)
             | PatternStep::Backref(_) => true,
-            PatternStep::Alt(alts) => alts.iter().any(|a| a.iter().any(|s| Self::step_consumes_input(s))),
+            PatternStep::Alt(alts) => alts
+                .iter()
+                .any(|a| a.iter().any(|s| Self::step_consumes_input(s))),
             _ => false,
         }
     }
 
     fn calc_min_len(steps: &[PatternStep]) -> usize {
-        steps.iter().map(|s| match s {
-            PatternStep::Byte(_) | PatternStep::ByteClass(_) => 1,
-            PatternStep::GreedyPlus(_) | PatternStep::GreedyPlusLookahead(_, _, _) => 1,
-            PatternStep::GreedyStar(_) | PatternStep::GreedyStarLookahead(_, _, _) => 0,
-            PatternStep::NonGreedyPlus(_, suf) => 1 + Self::calc_min_len(&[(**suf).clone()]),
-            PatternStep::NonGreedyStar(_, suf) => Self::calc_min_len(&[(**suf).clone()]),
-            PatternStep::Alt(alts) => alts.iter().map(|a| Self::calc_min_len(a)).min().unwrap_or(0),
-            PatternStep::CodepointClass(_, _) | PatternStep::GreedyCodepointPlus(_) => 1,
-            _ => 0,
-        }).sum()
+        steps
+            .iter()
+            .map(|s| match s {
+                PatternStep::Byte(_) | PatternStep::ByteClass(_) => 1,
+                PatternStep::GreedyPlus(_) | PatternStep::GreedyPlusLookahead(_, _, _) => 1,
+                PatternStep::GreedyStar(_) | PatternStep::GreedyStarLookahead(_, _, _) => 0,
+                PatternStep::NonGreedyPlus(_, suf) => 1 + Self::calc_min_len(&[(**suf).clone()]),
+                PatternStep::NonGreedyStar(_, suf) => Self::calc_min_len(&[(**suf).clone()]),
+                PatternStep::Alt(alts) => alts
+                    .iter()
+                    .map(|a| Self::calc_min_len(a))
+                    .min()
+                    .unwrap_or(0),
+                PatternStep::CodepointClass(_, _) | PatternStep::GreedyCodepointPlus(_) => 1,
+                _ => 0,
+            })
+            .sum()
     }
 
     fn combine_greedy_with_lookahead(steps: Vec<PatternStep>) -> Vec<PatternStep> {
@@ -179,37 +186,56 @@ impl TaggedNfaJitCompiler {
         let mut i = 0;
         while i < steps.len() {
             match &steps[i] {
-                PatternStep::GreedyPlus(r) if i + 1 < steps.len() => {
-                    match &steps[i + 1] {
-                        PatternStep::PositiveLookahead(inner) => {
-                            result.push(PatternStep::GreedyPlusLookahead(r.clone(), inner.clone(), true));
-                            i += 2; continue;
-                        }
-                        PatternStep::NegativeLookahead(inner) => {
-                            result.push(PatternStep::GreedyPlusLookahead(r.clone(), inner.clone(), false));
-                            i += 2; continue;
-                        }
-                        _ => {}
+                PatternStep::GreedyPlus(r) if i + 1 < steps.len() => match &steps[i + 1] {
+                    PatternStep::PositiveLookahead(inner) => {
+                        result.push(PatternStep::GreedyPlusLookahead(
+                            r.clone(),
+                            inner.clone(),
+                            true,
+                        ));
+                        i += 2;
+                        continue;
                     }
-                }
-                PatternStep::GreedyStar(r) if i + 1 < steps.len() => {
-                    match &steps[i + 1] {
-                        PatternStep::PositiveLookahead(inner) => {
-                            result.push(PatternStep::GreedyStarLookahead(r.clone(), inner.clone(), true));
-                            i += 2; continue;
-                        }
-                        PatternStep::NegativeLookahead(inner) => {
-                            result.push(PatternStep::GreedyStarLookahead(r.clone(), inner.clone(), false));
-                            i += 2; continue;
-                        }
-                        _ => {}
+                    PatternStep::NegativeLookahead(inner) => {
+                        result.push(PatternStep::GreedyPlusLookahead(
+                            r.clone(),
+                            inner.clone(),
+                            false,
+                        ));
+                        i += 2;
+                        continue;
                     }
-                }
+                    _ => {}
+                },
+                PatternStep::GreedyStar(r) if i + 1 < steps.len() => match &steps[i + 1] {
+                    PatternStep::PositiveLookahead(inner) => {
+                        result.push(PatternStep::GreedyStarLookahead(
+                            r.clone(),
+                            inner.clone(),
+                            true,
+                        ));
+                        i += 2;
+                        continue;
+                    }
+                    PatternStep::NegativeLookahead(inner) => {
+                        result.push(PatternStep::GreedyStarLookahead(
+                            r.clone(),
+                            inner.clone(),
+                            false,
+                        ));
+                        i += 2;
+                        continue;
+                    }
+                    _ => {}
+                },
                 PatternStep::Alt(alts) => {
-                    let combined: Vec<Vec<PatternStep>> = alts.iter()
-                        .map(|a| Self::combine_greedy_with_lookahead(a.clone())).collect();
+                    let combined: Vec<Vec<PatternStep>> = alts
+                        .iter()
+                        .map(|a| Self::combine_greedy_with_lookahead(a.clone()))
+                        .collect();
                     result.push(PatternStep::Alt(combined));
-                    i += 1; continue;
+                    i += 1;
+                    continue;
                 }
                 _ => {}
             }
@@ -219,7 +245,11 @@ impl TaggedNfaJitCompiler {
         result
     }
 
-    fn emit_range_check(&mut self, ranges: &[ByteRange], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_range_check(
+        &mut self,
+        ranges: &[ByteRange],
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         if ranges.len() == 1 {
             let r = &ranges[0];
@@ -255,7 +285,11 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_is_word_char(&mut self, word_label: dynasmrt::DynamicLabel, not_word_label: dynasmrt::DynamicLabel) {
+    fn emit_is_word_char(
+        &mut self,
+        word_label: dynasmrt::DynamicLabel,
+        not_word_label: dynasmrt::DynamicLabel,
+    ) {
         use dynasmrt::DynasmLabelApi;
         dynasm!(self.asm
             ; .arch aarch64
@@ -274,7 +308,11 @@ impl TaggedNfaJitCompiler {
         );
     }
 
-    fn emit_word_boundary_check(&mut self, fail_label: dynasmrt::DynamicLabel, is_boundary: bool) -> Result<()> {
+    fn emit_word_boundary_check(
+        &mut self,
+        fail_label: dynasmrt::DynamicLabel,
+        is_boundary: bool,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let prev_word = self.asm.new_dynamic_label();
         let prev_not_word = self.asm.new_dynamic_label();
@@ -415,7 +453,11 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_codepoint_class_membership_check(&mut self, cpclass: &CodepointClass, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_codepoint_class_membership_check(
+        &mut self,
+        cpclass: &CodepointClass,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let ascii_fast = self.asm.new_dynamic_label();
         let check_done = self.asm.new_dynamic_label();
@@ -512,7 +554,11 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_codepoint_class_check(&mut self, cpclass: &CodepointClass, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_codepoint_class_check(
+        &mut self,
+        cpclass: &CodepointClass,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let fail_stack = self.asm.new_dynamic_label();
         self.emit_utf8_decode(fail_label)?;
@@ -531,7 +577,11 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_greedy_codepoint_plus(&mut self, cpclass: &CodepointClass, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_greedy_codepoint_plus(
+        &mut self,
+        cpclass: &CodepointClass,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let loop_start = self.asm.new_dynamic_label();
         let loop_done = self.asm.new_dynamic_label();
@@ -564,7 +614,12 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_non_greedy_suffix_check(&mut self, suffix: &PatternStep, fail_label: dynasmrt::DynamicLabel, _success: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_non_greedy_suffix_check(
+        &mut self,
+        suffix: &PatternStep,
+        fail_label: dynasmrt::DynamicLabel,
+        _success: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         match suffix {
             PatternStep::Byte(b) => {
@@ -583,12 +638,21 @@ impl TaggedNfaJitCompiler {
                 self.emit_range_check(&bc.ranges, fail_label)?;
                 dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
             }
-            _ => return Err(Error::new(ErrorKind::Jit("Unsupported suffix".to_string()), "")),
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::Jit("Unsupported suffix".to_string()),
+                    "",
+                ))
+            }
         }
         Ok(())
     }
 
-    fn emit_step_inline(&mut self, step: &PatternStep, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_step_inline(
+        &mut self,
+        step: &PatternStep,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         match step {
             PatternStep::Byte(b) => {
@@ -625,12 +689,20 @@ impl TaggedNfaJitCompiler {
                 self.emit_range_check(&bc.ranges, ld)?;
                 dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>ls ; =>ld);
             }
-            PatternStep::CodepointClass(cp, _) => self.emit_codepoint_class_check(cp, fail_label)?,
-            PatternStep::GreedyCodepointPlus(cp) => self.emit_greedy_codepoint_plus(cp, fail_label)?,
+            PatternStep::CodepointClass(cp, _) => {
+                self.emit_codepoint_class_check(cp, fail_label)?
+            }
+            PatternStep::GreedyCodepointPlus(cp) => {
+                self.emit_greedy_codepoint_plus(cp, fail_label)?
+            }
             PatternStep::WordBoundary => self.emit_word_boundary_check(fail_label, true)?,
             PatternStep::NotWordBoundary => self.emit_word_boundary_check(fail_label, false)?,
-            PatternStep::StartOfText => { dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>fail_label); }
-            PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>fail_label); }
+            PatternStep::StartOfText => {
+                dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>fail_label);
+            }
+            PatternStep::EndOfText => {
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>fail_label);
+            }
             PatternStep::StartOfLine => {
                 let at_start = self.asm.new_dynamic_label();
                 dynasm!(self.asm
@@ -667,15 +739,25 @@ impl TaggedNfaJitCompiler {
                 }
                 dynasm!(self.asm ; .arch aarch64 ; =>success);
             }
-            _ => return Err(Error::new(ErrorKind::Jit(format!("Unsupported step: {:?}", step)), "")),
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::Jit(format!("Unsupported step: {:?}", step)),
+                    "",
+                ))
+            }
         }
         Ok(())
     }
 
-    fn emit_standalone_lookahead(&mut self, inner: &[PatternStep], fail_label: dynasmrt::DynamicLabel, positive: bool) -> Result<()> {
+    fn emit_standalone_lookahead(
+        &mut self,
+        inner: &[PatternStep],
+        fail_label: dynasmrt::DynamicLabel,
+        positive: bool,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let inner_match = self.asm.new_dynamic_label();
-        dynasm!(self.asm ; .arch aarch64 ; mov x9, x22);  // Save position
+        dynasm!(self.asm ; .arch aarch64 ; mov x9, x22); // Save position
 
         for step in inner {
             match step {
@@ -704,7 +786,12 @@ impl TaggedNfaJitCompiler {
                         dynasm!(self.asm ; .arch aarch64 ; cmp x9, x20 ; b.ne =>inner_match);
                     }
                 }
-                _ => return Err(Error::new(ErrorKind::Jit("Complex lookahead".to_string()), "")),
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::Jit("Complex lookahead".to_string()),
+                        "",
+                    ))
+                }
             }
         }
 
@@ -715,7 +802,13 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_lookbehind_check(&mut self, inner: &[PatternStep], min_len: usize, fail_label: dynasmrt::DynamicLabel, positive: bool) -> Result<()> {
+    fn emit_lookbehind_check(
+        &mut self,
+        inner: &[PatternStep],
+        min_len: usize,
+        fail_label: dynasmrt::DynamicLabel,
+        positive: bool,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let inner_match = self.asm.new_dynamic_label();
         let inner_mismatch = self.asm.new_dynamic_label();
@@ -737,7 +830,12 @@ impl TaggedNfaJitCompiler {
                     self.emit_range_check(&bc.ranges, inner_mismatch)?;
                     dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
                 }
-                _ => return Err(Error::new(ErrorKind::Jit("Unsupported lookbehind step".to_string()), "")),
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::Jit("Unsupported lookbehind step".to_string()),
+                        "",
+                    ))
+                }
             }
         }
         dynasm!(self.asm ; .arch aarch64 ; b =>inner_match);
@@ -757,10 +855,14 @@ impl TaggedNfaJitCompiler {
         use dynasmrt::DynasmLabelApi;
         let steps = self.extract_pattern_steps();
         let steps = Self::combine_greedy_with_lookahead(steps);
-        if steps.is_empty() { return self.compile_with_fallback(None); }
+        if steps.is_empty() {
+            return self.compile_with_fallback(None);
+        }
         for step in &steps {
             if let PatternStep::Alt(alts) = step {
-                if Self::has_unsupported_in_alt(alts) { return self.compile_with_fallback(Some(steps)); }
+                if Self::has_unsupported_in_alt(alts) {
+                    return self.compile_with_fallback(Some(steps));
+                }
             }
         }
         let has_backrefs = Self::has_backref(&steps);
@@ -820,7 +922,11 @@ impl TaggedNfaJitCompiler {
                     let remaining = &steps[si + 1..];
                     let needs_bt = remaining.iter().any(|s| Self::step_consumes_input(s));
                     if needs_bt {
-                        self.emit_greedy_plus_with_backtracking(&bc.ranges, remaining, byte_mismatch)?;
+                        self.emit_greedy_plus_with_backtracking(
+                            &bc.ranges,
+                            remaining,
+                            byte_mismatch,
+                        )?;
                         break;
                     } else {
                         let ls = self.asm.new_dynamic_label();
@@ -836,7 +942,11 @@ impl TaggedNfaJitCompiler {
                     let remaining = &steps[si + 1..];
                     let needs_bt = remaining.iter().any(|s| Self::step_consumes_input(s));
                     if needs_bt {
-                        self.emit_greedy_star_with_backtracking(&bc.ranges, remaining, byte_mismatch)?;
+                        self.emit_greedy_star_with_backtracking(
+                            &bc.ranges,
+                            remaining,
+                            byte_mismatch,
+                        )?;
                         break;
                     } else {
                         let ls = self.asm.new_dynamic_label();
@@ -847,21 +957,33 @@ impl TaggedNfaJitCompiler {
                     }
                 }
                 PatternStep::CaptureStart(_) | PatternStep::CaptureEnd(_) => {}
-                PatternStep::CodepointClass(cp, _) => self.emit_codepoint_class_check(cp, byte_mismatch)?,
+                PatternStep::CodepointClass(cp, _) => {
+                    self.emit_codepoint_class_check(cp, byte_mismatch)?
+                }
                 PatternStep::GreedyCodepointPlus(cp) => {
                     let remaining = &steps[si + 1..];
                     let needs_bt = remaining.iter().any(|s| Self::step_consumes_input(s));
                     if needs_bt {
-                        self.emit_greedy_codepoint_plus_with_backtracking(cp, remaining, byte_mismatch)?;
+                        self.emit_greedy_codepoint_plus_with_backtracking(
+                            cp,
+                            remaining,
+                            byte_mismatch,
+                        )?;
                         break;
                     } else {
                         self.emit_greedy_codepoint_plus(cp, byte_mismatch)?;
                     }
                 }
                 PatternStep::WordBoundary => self.emit_word_boundary_check(byte_mismatch, true)?,
-                PatternStep::NotWordBoundary => self.emit_word_boundary_check(byte_mismatch, false)?,
-                PatternStep::StartOfText => { dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>byte_mismatch); }
-                PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>byte_mismatch); }
+                PatternStep::NotWordBoundary => {
+                    self.emit_word_boundary_check(byte_mismatch, false)?
+                }
+                PatternStep::StartOfText => {
+                    dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>byte_mismatch);
+                }
+                PatternStep::EndOfText => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>byte_mismatch);
+                }
                 PatternStep::StartOfLine => {
                     let at_start = self.asm.new_dynamic_label();
                     dynasm!(self.asm ; .arch aarch64 ; cbz x22, =>at_start ; sub x1, x22, 1 ; ldrb w0, [x19, x1] ; cmp w0, 0x0A ; b.ne =>byte_mismatch ; =>at_start);
@@ -870,20 +992,38 @@ impl TaggedNfaJitCompiler {
                     let at_end = self.asm.new_dynamic_label();
                     dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.eq =>at_end ; ldrb w0, [x19, x22] ; cmp w0, 0x0A ; b.ne =>byte_mismatch ; =>at_end);
                 }
-                PatternStep::PositiveLookahead(inner) => self.emit_standalone_lookahead(inner, byte_mismatch, true)?,
-                PatternStep::NegativeLookahead(inner) => self.emit_standalone_lookahead(inner, byte_mismatch, false)?,
-                PatternStep::PositiveLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, byte_mismatch, true)?,
-                PatternStep::NegativeLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, byte_mismatch, false)?,
+                PatternStep::PositiveLookahead(inner) => {
+                    self.emit_standalone_lookahead(inner, byte_mismatch, true)?
+                }
+                PatternStep::NegativeLookahead(inner) => {
+                    self.emit_standalone_lookahead(inner, byte_mismatch, false)?
+                }
+                PatternStep::PositiveLookbehind(inner, ml) => {
+                    self.emit_lookbehind_check(inner, *ml, byte_mismatch, true)?
+                }
+                PatternStep::NegativeLookbehind(inner, ml) => {
+                    self.emit_lookbehind_check(inner, *ml, byte_mismatch, false)?
+                }
                 PatternStep::Alt(alts) => {
-                    if Self::has_unsupported_in_alt(alts) { return self.compile_with_fallback(Some(steps.clone())); }
+                    if Self::has_unsupported_in_alt(alts) {
+                        return self.compile_with_fallback(Some(steps.clone()));
+                    }
                     let alt_success = self.asm.new_dynamic_label();
                     dynasm!(self.asm ; .arch aarch64 ; mov x23, x22);
                     for (ai, alt_steps) in alts.iter().enumerate() {
                         let is_last = ai == alts.len() - 1;
-                        let try_next = if is_last { byte_mismatch } else { self.asm.new_dynamic_label() };
-                        for s in alt_steps { self.emit_alt_step(s, try_next)?; }
+                        let try_next = if is_last {
+                            byte_mismatch
+                        } else {
+                            self.asm.new_dynamic_label()
+                        };
+                        for s in alt_steps {
+                            self.emit_alt_step(s, try_next)?;
+                        }
                         dynasm!(self.asm ; .arch aarch64 ; b =>alt_success);
-                        if !is_last { dynasm!(self.asm ; .arch aarch64 ; =>try_next ; mov x22, x23); }
+                        if !is_last {
+                            dynasm!(self.asm ; .arch aarch64 ; =>try_next ; mov x22, x23);
+                        }
                     }
                     dynasm!(self.asm ; .arch aarch64 ; =>alt_success);
                 }
@@ -919,8 +1059,12 @@ impl TaggedNfaJitCompiler {
                     self.emit_range_check(&bc.ranges, byte_mismatch)?;
                     dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>try_suf ; =>matched);
                 }
-                PatternStep::GreedyPlusLookahead(bc, la, pos) => self.emit_greedy_plus_with_lookahead(&bc.ranges, la, *pos, byte_mismatch)?,
-                PatternStep::GreedyStarLookahead(bc, la, pos) => self.emit_greedy_star_with_lookahead(&bc.ranges, la, *pos, byte_mismatch)?,
+                PatternStep::GreedyPlusLookahead(bc, la, pos) => {
+                    self.emit_greedy_plus_with_lookahead(&bc.ranges, la, *pos, byte_mismatch)?
+                }
+                PatternStep::GreedyStarLookahead(bc, la, pos) => {
+                    self.emit_greedy_star_with_lookahead(&bc.ranges, la, *pos, byte_mismatch)?
+                }
                 PatternStep::Backref(_) => unreachable!("Backref handled above"),
             }
         }
@@ -949,8 +1093,12 @@ impl TaggedNfaJitCompiler {
             ; ret
         );
 
-        let has_captures = steps.iter().any(|s| matches!(s, PatternStep::CaptureStart(_) | PatternStep::CaptureEnd(_)));
-        let caps_off = if has_captures { self.emit_captures_fn(&steps)? } else {
+        let has_captures = steps
+            .iter()
+            .any(|s| matches!(s, PatternStep::CaptureStart(_) | PatternStep::CaptureEnd(_)));
+        let caps_off = if has_captures {
+            self.emit_captures_fn(&steps)?
+        } else {
             let off = self.asm.offset();
             dynasm!(self.asm ; .arch aarch64 ; movn x0, 1 ; ret);
             off
@@ -959,11 +1107,20 @@ impl TaggedNfaJitCompiler {
         self.finalize(find_offset, caps_off, false, Some(steps))
     }
 
-    fn emit_alt_step(&mut self, step: &PatternStep, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_alt_step(
+        &mut self,
+        step: &PatternStep,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         self.emit_step_inline(step, fail_label)
     }
 
-    fn emit_greedy_plus_with_backtracking(&mut self, ranges: &[ByteRange], remaining: &[PatternStep], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_greedy_plus_with_backtracking(
+        &mut self,
+        ranges: &[ByteRange],
+        remaining: &[PatternStep],
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let greedy_loop = self.asm.new_dynamic_label();
         let greedy_done = self.asm.new_dynamic_label();
@@ -977,7 +1134,9 @@ impl TaggedNfaJitCompiler {
         dynasm!(self.asm ; .arch aarch64 ; =>greedy_loop ; cmp x22, x20 ; b.ge =>greedy_done ; ldrb w0, [x19, x22]);
         self.emit_range_check(ranges, greedy_done)?;
         dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>greedy_loop ; =>greedy_done ; =>try_remaining);
-        for s in remaining { self.emit_step_inline(s, backtrack)?; }
+        for s in remaining {
+            self.emit_step_inline(s, backtrack)?;
+        }
         dynasm!(self.asm
             ; .arch aarch64
             ; b =>success
@@ -987,7 +1146,12 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_greedy_star_with_backtracking(&mut self, ranges: &[ByteRange], remaining: &[PatternStep], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_greedy_star_with_backtracking(
+        &mut self,
+        ranges: &[ByteRange],
+        remaining: &[PatternStep],
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let greedy_loop = self.asm.new_dynamic_label();
         let greedy_done = self.asm.new_dynamic_label();
@@ -999,7 +1163,9 @@ impl TaggedNfaJitCompiler {
         dynasm!(self.asm ; .arch aarch64 ; =>greedy_loop ; cmp x22, x20 ; b.ge =>greedy_done ; ldrb w0, [x19, x22]);
         self.emit_range_check(ranges, greedy_done)?;
         dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>greedy_loop ; =>greedy_done ; =>try_remaining);
-        for s in remaining { self.emit_step_inline(s, backtrack)?; }
+        for s in remaining {
+            self.emit_step_inline(s, backtrack)?;
+        }
         dynasm!(self.asm
             ; .arch aarch64
             ; b =>success
@@ -1009,14 +1175,125 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_greedy_codepoint_plus_with_backtracking(&mut self, cpclass: &CodepointClass, remaining: &[PatternStep], fail_label: dynasmrt::DynamicLabel) -> Result<()> {
-        // Simplified: use normal greedy then try remaining
-        self.emit_greedy_codepoint_plus(cpclass, fail_label)?;
-        for s in remaining { self.emit_step_inline(s, fail_label)?; }
+    fn emit_greedy_codepoint_plus_with_backtracking(
+        &mut self,
+        cpclass: &CodepointClass,
+        remaining: &[PatternStep],
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
+        use dynasmrt::DynasmLabelApi;
+
+        // For codepoint backtracking, we save character boundaries on the stack
+        let loop_start = self.asm.new_dynamic_label();
+        let loop_done = self.asm.new_dynamic_label();
+        let try_remaining = self.asm.new_dynamic_label();
+        let backtrack = self.asm.new_dynamic_label();
+        let success = self.asm.new_dynamic_label();
+        let first_fail_stack = self.asm.new_dynamic_label();
+        let loop_fail_no_stack = self.asm.new_dynamic_label();
+        let loop_fail_stack = self.asm.new_dynamic_label();
+        let no_more_boundaries = self.asm.new_dynamic_label();
+
+        // x24 will track the number of saved boundaries on stack
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; mov x24, xzr                    // x24 = boundary count = 0
+        );
+
+        // First iteration: must match at least one codepoint
+        self.emit_utf8_decode(fail_label)?;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; str x1, [sp, -16]!              // Save byte length
+        );
+        self.emit_codepoint_class_membership_check(cpclass, first_fail_stack)?;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; ldr x1, [sp], 16                // Restore byte length
+            ; add x22, x22, x1                // Advance position
+            ; str x22, [sp, -16]!             // Save boundary position
+            ; add x24, x24, 1                 // boundary count++
+
+            // Greedy loop: match more codepoints
+            ; =>loop_start
+        );
+
+        self.emit_utf8_decode(loop_fail_no_stack)?;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; str x1, [sp, -16]!              // Save byte length
+        );
+        self.emit_codepoint_class_membership_check(cpclass, loop_fail_stack)?;
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; ldr x1, [sp], 16                // Restore byte length
+            ; add x22, x22, x1                // Advance position
+            ; str x22, [sp, -16]!             // Save boundary position
+            ; add x24, x24, 1                 // boundary count++
+            ; b =>loop_start
+
+            ; =>first_fail_stack
+            ; add sp, sp, 16                  // Pop saved byte length
+            ; b =>fail_label                  // First match failed - overall fail
+
+            ; =>loop_fail_no_stack
+            ; b =>loop_done
+
+            ; =>loop_fail_stack
+            ; add sp, sp, 16                  // Pop saved byte length
+            ; b =>loop_done
+
+            ; =>loop_done
+            // Greedy matching done
+            // Stack has boundary positions, x24 = count
+            // Try remaining steps with backtracking
+
+            ; =>try_remaining
+        );
+
+        // Emit code for remaining steps
+        for step in remaining {
+            self.emit_step_inline(step, backtrack)?;
+        }
+
+        // All remaining steps matched - success!
+        // Clean up stack (pop all saved boundaries)
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>success
+            ; lsl x0, x24, 4                  // x0 = boundary_count * 16 (stack slot size)
+            ; add sp, sp, x0                  // Pop all boundary positions
+            ; b >done
+
+            ; =>backtrack
+            // Remaining steps failed - backtrack to previous boundary
+            ; cmp x24, 1
+            ; b.le =>no_more_boundaries       // Need at least 1 match (plus semantics)
+
+            ; ldr x22, [sp], 16               // Pop and discard current boundary
+            ; sub x24, x24, 1
+            ; ldr x22, [sp]                   // Peek previous boundary (don't pop yet)
+            ; b =>try_remaining
+
+            ; =>no_more_boundaries
+            // Can't backtrack more - clean up and fail
+            ; lsl x0, x24, 4                  // x0 = boundary_count * 16
+            ; add sp, sp, x0                  // Pop all remaining boundaries
+            ; b =>fail_label
+
+            ; done:
+        );
+
         Ok(())
     }
 
-    fn emit_greedy_plus_with_lookahead(&mut self, ranges: &[ByteRange], la_steps: &[PatternStep], positive: bool, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_greedy_plus_with_lookahead(
+        &mut self,
+        ranges: &[ByteRange],
+        la_steps: &[PatternStep],
+        positive: bool,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let greedy_loop = self.asm.new_dynamic_label();
         let greedy_done = self.asm.new_dynamic_label();
@@ -1043,7 +1320,9 @@ impl TaggedNfaJitCompiler {
                     self.emit_range_check(&bc.ranges, la_mismatch)?;
                     dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
                 }
-                PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>la_mismatch); }
+                PatternStep::EndOfText => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>la_mismatch);
+                }
                 _ => {}
             }
         }
@@ -1057,7 +1336,13 @@ impl TaggedNfaJitCompiler {
         Ok(())
     }
 
-    fn emit_greedy_star_with_lookahead(&mut self, ranges: &[ByteRange], la_steps: &[PatternStep], positive: bool, fail_label: dynasmrt::DynamicLabel) -> Result<()> {
+    fn emit_greedy_star_with_lookahead(
+        &mut self,
+        ranges: &[ByteRange],
+        la_steps: &[PatternStep],
+        positive: bool,
+        fail_label: dynasmrt::DynamicLabel,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         let greedy_loop = self.asm.new_dynamic_label();
         let greedy_done = self.asm.new_dynamic_label();
@@ -1082,7 +1367,9 @@ impl TaggedNfaJitCompiler {
                     self.emit_range_check(&bc.ranges, la_mismatch)?;
                     dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1);
                 }
-                PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>la_mismatch); }
+                PatternStep::EndOfText => {
+                    dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>la_mismatch);
+                }
                 _ => {}
             }
         }
@@ -1100,10 +1387,14 @@ impl TaggedNfaJitCompiler {
         use dynasmrt::DynasmLabelApi;
         let offset = self.asm.offset();
         let min_len = Self::calc_min_len(steps);
-        let max_cap_idx = steps.iter().filter_map(|s| match s {
-            PatternStep::CaptureStart(i) | PatternStep::CaptureEnd(i) => Some(*i),
-            _ => None,
-        }).max().unwrap_or(0);
+        let max_cap_idx = steps
+            .iter()
+            .filter_map(|s| match s {
+                PatternStep::CaptureStart(i) | PatternStep::CaptureEnd(i) => Some(*i),
+                _ => None,
+            })
+            .max()
+            .unwrap_or(0);
         let num_slots = (max_cap_idx as usize + 1) * 2;
 
         // Prologue: x0=input, x1=len, x2=ctx, x3=captures
@@ -1178,7 +1469,12 @@ impl TaggedNfaJitCompiler {
         Ok(offset)
     }
 
-    fn emit_capture_step(&mut self, step: &PatternStep, fail_label: dynasmrt::DynamicLabel, _num_slots: usize) -> Result<()> {
+    fn emit_capture_step(
+        &mut self,
+        step: &PatternStep,
+        fail_label: dynasmrt::DynamicLabel,
+        _num_slots: usize,
+    ) -> Result<()> {
         use dynasmrt::DynasmLabelApi;
         match step {
             PatternStep::Byte(b) => {
@@ -1219,24 +1515,48 @@ impl TaggedNfaJitCompiler {
                 dynasm!(self.asm ; .arch aarch64 ; str x22, [sp, -16]!);
                 for (ai, alt_steps) in alts.iter().enumerate() {
                     let is_last = ai == alts.len() - 1;
-                    let try_next = if is_last { alt_fail } else { self.asm.new_dynamic_label() };
-                    for s in alt_steps { self.emit_capture_step(s, try_next, _num_slots)?; }
+                    let try_next = if is_last {
+                        alt_fail
+                    } else {
+                        self.asm.new_dynamic_label()
+                    };
+                    for s in alt_steps {
+                        self.emit_capture_step(s, try_next, _num_slots)?;
+                    }
                     dynasm!(self.asm ; .arch aarch64 ; add sp, sp, 16 ; b =>success);
-                    if !is_last { dynasm!(self.asm ; .arch aarch64 ; =>try_next ; ldr x22, [sp]); }
+                    if !is_last {
+                        dynasm!(self.asm ; .arch aarch64 ; =>try_next ; ldr x22, [sp]);
+                    }
                 }
                 dynasm!(self.asm ; .arch aarch64 ; =>alt_fail ; add sp, sp, 16 ; b =>fail_label);
                 dynasm!(self.asm ; .arch aarch64 ; =>success);
             }
-            PatternStep::CodepointClass(cp, _) => self.emit_codepoint_class_check(cp, fail_label)?,
-            PatternStep::GreedyCodepointPlus(cp) => self.emit_greedy_codepoint_plus(cp, fail_label)?,
+            PatternStep::CodepointClass(cp, _) => {
+                self.emit_codepoint_class_check(cp, fail_label)?
+            }
+            PatternStep::GreedyCodepointPlus(cp) => {
+                self.emit_greedy_codepoint_plus(cp, fail_label)?
+            }
             PatternStep::WordBoundary => self.emit_word_boundary_check(fail_label, true)?,
             PatternStep::NotWordBoundary => self.emit_word_boundary_check(fail_label, false)?,
-            PatternStep::PositiveLookahead(inner) => self.emit_standalone_lookahead(inner, fail_label, true)?,
-            PatternStep::NegativeLookahead(inner) => self.emit_standalone_lookahead(inner, fail_label, false)?,
-            PatternStep::PositiveLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, fail_label, true)?,
-            PatternStep::NegativeLookbehind(inner, ml) => self.emit_lookbehind_check(inner, *ml, fail_label, false)?,
-            PatternStep::StartOfText => { dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>fail_label); }
-            PatternStep::EndOfText => { dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>fail_label); }
+            PatternStep::PositiveLookahead(inner) => {
+                self.emit_standalone_lookahead(inner, fail_label, true)?
+            }
+            PatternStep::NegativeLookahead(inner) => {
+                self.emit_standalone_lookahead(inner, fail_label, false)?
+            }
+            PatternStep::PositiveLookbehind(inner, ml) => {
+                self.emit_lookbehind_check(inner, *ml, fail_label, true)?
+            }
+            PatternStep::NegativeLookbehind(inner, ml) => {
+                self.emit_lookbehind_check(inner, *ml, fail_label, false)?
+            }
+            PatternStep::StartOfText => {
+                dynasm!(self.asm ; .arch aarch64 ; cbnz x22, =>fail_label);
+            }
+            PatternStep::EndOfText => {
+                dynasm!(self.asm ; .arch aarch64 ; cmp x22, x20 ; b.ne =>fail_label);
+            }
             PatternStep::StartOfLine => {
                 let at_start = self.asm.new_dynamic_label();
                 dynasm!(self.asm ; .arch aarch64 ; cbz x22, =>at_start ; sub x1, x22, 1 ; ldrb w0, [x19, x1] ; cmp w0, 0x0A ; b.ne =>fail_label ; =>at_start);
@@ -1308,8 +1628,12 @@ impl TaggedNfaJitCompiler {
                 self.emit_range_check(&bc.ranges, fail_label)?;
                 dynasm!(self.asm ; .arch aarch64 ; add x22, x22, 1 ; b =>try_suf ; =>matched);
             }
-            PatternStep::GreedyPlusLookahead(bc, la, pos) => self.emit_greedy_plus_with_lookahead(&bc.ranges, la, *pos, fail_label)?,
-            PatternStep::GreedyStarLookahead(bc, la, pos) => self.emit_greedy_star_with_lookahead(&bc.ranges, la, *pos, fail_label)?,
+            PatternStep::GreedyPlusLookahead(bc, la, pos) => {
+                self.emit_greedy_plus_with_lookahead(&bc.ranges, la, *pos, fail_label)?
+            }
+            PatternStep::GreedyStarLookahead(bc, la, pos) => {
+                self.emit_greedy_star_with_lookahead(&bc.ranges, la, *pos, fail_label)?
+            }
         }
         Ok(())
     }
@@ -1319,11 +1643,20 @@ impl TaggedNfaJitCompiler {
         self.extract_from_state(self.nfa.start, &mut visited, None)
     }
 
-    fn extract_from_state(&self, start: StateId, visited: &mut [bool], end_state: Option<StateId>) -> Vec<PatternStep> {
+    fn extract_from_state(
+        &self,
+        start: StateId,
+        visited: &mut [bool],
+        end_state: Option<StateId>,
+    ) -> Vec<PatternStep> {
         let mut steps = Vec::new();
         let mut current = start;
         loop {
-            if let Some(end) = end_state { if current == end { break; } }
+            if let Some(end) = end_state {
+                if current == end {
+                    break;
+                }
+            }
             let state = &self.nfa.states[current as usize];
             if let Some(ref instr) = state.instruction {
                 match instr {
@@ -1335,43 +1668,61 @@ impl TaggedNfaJitCompiler {
                             let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
                             if e0 == current {
                                 steps.push(PatternStep::GreedyCodepointPlus(cp.clone()));
-                                visited[current as usize] = true; visited[*t as usize] = true;
-                                current = e1; continue;
+                                visited[current as usize] = true;
+                                visited[*t as usize] = true;
+                                current = e1;
+                                continue;
                             } else if e1 == current {
                                 steps.push(PatternStep::GreedyCodepointPlus(cp.clone()));
-                                visited[current as usize] = true; visited[*t as usize] = true;
-                                current = e0; continue;
+                                visited[current as usize] = true;
+                                visited[*t as usize] = true;
+                                current = e0;
+                                continue;
                             }
                         }
                         steps.push(PatternStep::CodepointClass(cp.clone(), *t));
-                        current = *t; continue;
+                        current = *t;
+                        continue;
                     }
                     NfaInstruction::Backref(i) => {
                         steps.push(PatternStep::Backref(*i));
                         if state.epsilon.len() == 1 {
-                            visited[current as usize] = true; current = state.epsilon[0]; continue;
-                        } else if state.epsilon.is_empty() && state.is_match { break; }
-                        else { return Vec::new(); }
+                            visited[current as usize] = true;
+                            current = state.epsilon[0];
+                            continue;
+                        } else if state.epsilon.is_empty() && state.is_match {
+                            break;
+                        } else {
+                            return Vec::new();
+                        }
                     }
                     NfaInstruction::PositiveLookahead(inner) => {
                         let inner_steps = self.extract_lookaround_steps(inner);
-                        if inner_steps.is_empty() { return Vec::new(); }
+                        if inner_steps.is_empty() {
+                            return Vec::new();
+                        }
                         steps.push(PatternStep::PositiveLookahead(inner_steps));
                     }
                     NfaInstruction::NegativeLookahead(inner) => {
                         let inner_steps = self.extract_lookaround_steps(inner);
-                        if inner_steps.is_empty() { return Vec::new(); }
+                        if inner_steps.is_empty() {
+                            return Vec::new();
+                        }
                         steps.push(PatternStep::NegativeLookahead(inner_steps));
                     }
                     NfaInstruction::PositiveLookbehind(inner) => {
                         let inner_steps = self.extract_lookaround_steps(inner);
-                        if inner_steps.is_empty() { return Vec::new(); }
+                        if inner_steps.is_empty() {
+                            return Vec::new();
+                        }
                         let ml = Self::calc_min_len(&inner_steps);
                         steps.push(PatternStep::PositiveLookbehind(inner_steps, ml));
                     }
                     NfaInstruction::NegativeLookbehind(inner) => {
                         let inner_steps = self.extract_lookaround_steps(inner);
-                        if inner_steps.is_empty() { return Vec::new(); }
+                        if inner_steps.is_empty() {
+                            return Vec::new();
+                        }
                         let ml = Self::calc_min_len(&inner_steps);
                         steps.push(PatternStep::NegativeLookbehind(inner_steps, ml));
                     }
@@ -1384,59 +1735,92 @@ impl TaggedNfaJitCompiler {
                     NfaInstruction::NonGreedyExit => {}
                 }
             }
-            if state.is_match { break; }
+            if state.is_match {
+                break;
+            }
             if !state.transitions.is_empty() {
                 let target = state.transitions[0].1;
-                if !state.transitions.iter().all(|(_, t)| *t == target) { return Vec::new(); }
-                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                if !state.transitions.iter().all(|(_, t)| *t == target) {
+                    return Vec::new();
+                }
+                let ranges: Vec<ByteRange> =
+                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
                 let ts = &self.nfa.states[target as usize];
                 if ts.epsilon.len() == 2 && ts.transitions.is_empty() {
                     let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
                     if e0 == current {
                         steps.push(PatternStep::GreedyPlus(ByteClass::new(ranges)));
-                        current = e1; visited[target as usize] = true; continue;
+                        current = e1;
+                        visited[target as usize] = true;
+                        continue;
                     }
                     let ms = &self.nfa.states[e0 as usize];
-                    if e1 == current && ms.transitions.is_empty() && ms.epsilon.len() == 1 && matches!(ms.instruction, Some(NfaInstruction::NonGreedyExit)) {
+                    if e1 == current
+                        && ms.transitions.is_empty()
+                        && ms.epsilon.len() == 1
+                        && matches!(ms.instruction, Some(NfaInstruction::NonGreedyExit))
+                    {
                         let exit = ms.epsilon[0];
                         if let Some(suf) = self.extract_single_step(exit) {
-                            steps.push(PatternStep::NonGreedyPlus(ByteClass::new(ranges), Box::new(suf)));
-                            visited[target as usize] = true; visited[e0 as usize] = true; visited[exit as usize] = true;
-                            current = self.advance_past_step(exit); continue;
+                            steps.push(PatternStep::NonGreedyPlus(
+                                ByteClass::new(ranges),
+                                Box::new(suf),
+                            ));
+                            visited[target as usize] = true;
+                            visited[e0 as usize] = true;
+                            visited[exit as usize] = true;
+                            current = self.advance_past_step(exit);
+                            continue;
                         }
                         return Vec::new();
                     }
                 }
-                if visited[current as usize] { return Vec::new(); }
+                if visited[current as usize] {
+                    return Vec::new();
+                }
                 visited[current as usize] = true;
                 if ranges.len() == 1 && ranges[0].start == ranges[0].end {
                     steps.push(PatternStep::Byte(ranges[0].start));
                 } else {
                     steps.push(PatternStep::ByteClass(ByteClass::new(ranges)));
                 }
-                current = target; continue;
+                current = target;
+                continue;
             }
             if state.epsilon.len() == 1 && state.transitions.is_empty() {
-                if visited[current as usize] { return Vec::new(); }
+                if visited[current as usize] {
+                    return Vec::new();
+                }
                 visited[current as usize] = true;
-                current = state.epsilon[0]; continue;
+                current = state.epsilon[0];
+                continue;
             }
             if state.epsilon.len() > 1 && state.transitions.is_empty() {
                 if state.epsilon.len() == 2 {
                     let e0s = &self.nfa.states[state.epsilon[0] as usize];
-                    if e0s.transitions.is_empty() && e0s.epsilon.len() == 1 && matches!(e0s.instruction, Some(NfaInstruction::NonGreedyExit)) {
+                    if e0s.transitions.is_empty()
+                        && e0s.epsilon.len() == 1
+                        && matches!(e0s.instruction, Some(NfaInstruction::NonGreedyExit))
+                    {
                         let ps = state.epsilon[1];
                         let pst = &self.nfa.states[ps as usize];
                         if !pst.transitions.is_empty() {
                             let t = pst.transitions[0].1;
                             if pst.transitions.iter().all(|(_, tt)| *tt == t) {
-                                let ranges: Vec<ByteRange> = pst.transitions.iter().map(|(r, _)| r.clone()).collect();
+                                let ranges: Vec<ByteRange> =
+                                    pst.transitions.iter().map(|(r, _)| r.clone()).collect();
                                 let exit = e0s.epsilon[0];
                                 if let Some(suf) = self.extract_single_step(exit) {
-                                    steps.push(PatternStep::NonGreedyStar(ByteClass::new(ranges), Box::new(suf)));
-                                    visited[current as usize] = true; visited[state.epsilon[0] as usize] = true;
-                                    visited[ps as usize] = true; visited[exit as usize] = true;
-                                    current = self.advance_past_step(exit); continue;
+                                    steps.push(PatternStep::NonGreedyStar(
+                                        ByteClass::new(ranges),
+                                        Box::new(suf),
+                                    ));
+                                    visited[current as usize] = true;
+                                    visited[state.epsilon[0] as usize] = true;
+                                    visited[ps as usize] = true;
+                                    visited[exit as usize] = true;
+                                    current = self.advance_past_step(exit);
+                                    continue;
                                 }
                             }
                         }
@@ -1444,20 +1828,27 @@ impl TaggedNfaJitCompiler {
                     }
                 }
                 let common_end = self.find_alternation_end(current);
-                if common_end.is_none() { return Vec::new(); }
+                if common_end.is_none() {
+                    return Vec::new();
+                }
                 let ce = common_end.unwrap();
                 let mut alts = Vec::new();
                 for &alt_start in &state.epsilon {
                     let mut av = visited.to_vec();
                     let alt_steps = self.extract_from_state(alt_start, &mut av, Some(ce));
-                    if alt_steps.is_empty() && !self.is_trivial_path(alt_start, ce) { return Vec::new(); }
+                    if alt_steps.is_empty() && !self.is_trivial_path(alt_start, ce) {
+                        return Vec::new();
+                    }
                     alts.push(alt_steps);
                 }
                 steps.push(PatternStep::Alt(alts));
                 visited[current as usize] = true;
-                current = ce; continue;
+                current = ce;
+                continue;
             }
-            if state.transitions.is_empty() && state.epsilon.is_empty() { break; }
+            if state.transitions.is_empty() && state.epsilon.is_empty() {
+                break;
+            }
             return Vec::new();
         }
         steps
@@ -1468,9 +1859,13 @@ impl TaggedNfaJitCompiler {
         let mut steps = Vec::new();
         let mut current = inner.start;
         loop {
-            if current as usize >= inner.states.len() { return Vec::new(); }
+            if current as usize >= inner.states.len() {
+                return Vec::new();
+            }
             let state = &inner.states[current as usize];
-            if state.is_match { break; }
+            if state.is_match {
+                break;
+            }
             if let Some(ref instr) = state.instruction {
                 match instr {
                     NfaInstruction::WordBoundary => steps.push(PatternStep::WordBoundary),
@@ -1481,70 +1876,120 @@ impl TaggedNfaJitCompiler {
             }
             if !state.transitions.is_empty() {
                 let t = state.transitions[0].1;
-                if !state.transitions.iter().all(|(_, tt)| *tt == t) { return Vec::new(); }
-                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                if !state.transitions.iter().all(|(_, tt)| *tt == t) {
+                    return Vec::new();
+                }
+                let ranges: Vec<ByteRange> =
+                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
                 let ts = &inner.states[t as usize];
                 if ts.transitions.is_empty() && ts.epsilon.len() == 2 {
                     let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
                     if e0 == current {
                         steps.push(PatternStep::GreedyPlus(ByteClass::new(ranges)));
-                        if visited[t as usize] { return Vec::new(); }
-                        visited[t as usize] = true; current = e1; continue;
+                        if visited[t as usize] {
+                            return Vec::new();
+                        }
+                        visited[t as usize] = true;
+                        current = e1;
+                        continue;
                     } else if e1 == current {
                         steps.push(PatternStep::GreedyPlus(ByteClass::new(ranges)));
-                        if visited[t as usize] { return Vec::new(); }
-                        visited[t as usize] = true; current = e0; continue;
+                        if visited[t as usize] {
+                            return Vec::new();
+                        }
+                        visited[t as usize] = true;
+                        current = e0;
+                        continue;
                     }
                 }
-                if visited[current as usize] { return Vec::new(); }
+                if visited[current as usize] {
+                    return Vec::new();
+                }
                 visited[current as usize] = true;
                 if ranges.len() == 1 && ranges[0].start == ranges[0].end {
                     steps.push(PatternStep::Byte(ranges[0].start));
                 } else {
                     steps.push(PatternStep::ByteClass(ByteClass::new(ranges)));
                 }
-                current = t; continue;
+                current = t;
+                continue;
             }
             if state.epsilon.len() == 1 && state.transitions.is_empty() {
-                if visited[current as usize] { return Vec::new(); }
+                if visited[current as usize] {
+                    return Vec::new();
+                }
                 visited[current as usize] = true;
-                current = state.epsilon[0]; continue;
+                current = state.epsilon[0];
+                continue;
             }
             if state.epsilon.len() == 2 && state.transitions.is_empty() {
                 let (e0, e1) = (state.epsilon[0], state.epsilon[1]);
-                if let Some((r, exit)) = self.detect_greedy_star_lookaround(inner, current, e0, e1, &visited) {
+                if let Some((r, exit)) =
+                    self.detect_greedy_star_lookaround(inner, current, e0, e1, &visited)
+                {
                     steps.push(PatternStep::GreedyStar(ByteClass::new(r)));
-                    visited[current as usize] = true; current = exit; continue;
+                    visited[current as usize] = true;
+                    current = exit;
+                    continue;
                 }
-                if let Some((r, exit)) = self.detect_greedy_star_lookaround(inner, current, e1, e0, &visited) {
+                if let Some((r, exit)) =
+                    self.detect_greedy_star_lookaround(inner, current, e1, e0, &visited)
+                {
                     steps.push(PatternStep::GreedyStar(ByteClass::new(r)));
-                    visited[current as usize] = true; current = exit; continue;
+                    visited[current as usize] = true;
+                    current = exit;
+                    continue;
                 }
                 return Vec::new();
             }
-            if !state.epsilon.is_empty() || !state.transitions.is_empty() { return Vec::new(); }
+            if !state.epsilon.is_empty() || !state.transitions.is_empty() {
+                return Vec::new();
+            }
             break;
         }
         steps
     }
 
-    fn detect_greedy_star_lookaround(&self, inner: &Nfa, branch: StateId, loop_start: StateId, exit: StateId, visited: &[bool]) -> Option<(Vec<ByteRange>, StateId)> {
-        if loop_start as usize >= inner.states.len() { return None; }
+    fn detect_greedy_star_lookaround(
+        &self,
+        inner: &Nfa,
+        branch: StateId,
+        loop_start: StateId,
+        exit: StateId,
+        visited: &[bool],
+    ) -> Option<(Vec<ByteRange>, StateId)> {
+        if loop_start as usize >= inner.states.len() {
+            return None;
+        }
         let ls = &inner.states[loop_start as usize];
-        if ls.transitions.is_empty() { return None; }
+        if ls.transitions.is_empty() {
+            return None;
+        }
         let t = ls.transitions[0].1;
-        if !ls.transitions.iter().all(|(_, tt)| *tt == t) { return None; }
+        if !ls.transitions.iter().all(|(_, tt)| *tt == t) {
+            return None;
+        }
         let ranges: Vec<ByteRange> = ls.transitions.iter().map(|(r, _)| r.clone()).collect();
         let ts = &inner.states[t as usize];
         if ts.epsilon.len() == 1 {
             let back = ts.epsilon[0];
-            if (back == branch || back == loop_start) && !visited[loop_start as usize] { return Some((ranges, exit)); }
+            if (back == branch || back == loop_start) && !visited[loop_start as usize] {
+                return Some((ranges, exit));
+            }
         }
         if ts.epsilon.len() == 2 {
             let (e0, e1) = (ts.epsilon[0], ts.epsilon[1]);
-            let (back, fwd) = if e0 == branch || e0 == loop_start { (e0, e1) } else if e1 == branch || e1 == loop_start { (e1, e0) } else { return None; };
+            let (back, fwd) = if e0 == branch || e0 == loop_start {
+                (e0, e1)
+            } else if e1 == branch || e1 == loop_start {
+                (e1, e0)
+            } else {
+                return None;
+            };
             let _ = back;
-            if fwd == exit && !visited[loop_start as usize] { return Some((ranges, exit)); }
+            if fwd == exit && !visited[loop_start as usize] {
+                return Some((ranges, exit));
+            }
         }
         None
     }
@@ -1554,38 +1999,87 @@ impl TaggedNfaJitCompiler {
     }
 
     fn find_alternation_end_depth(&self, start: StateId, depth: usize) -> Option<StateId> {
-        if depth > 20 { return None; }
+        if depth > 20 {
+            return None;
+        }
         let state = &self.nfa.states[start as usize];
-        if state.epsilon.len() < 2 { return None; }
+        if state.epsilon.len() < 2 {
+            return None;
+        }
         let mut ends = Vec::new();
         for &alt_start in &state.epsilon {
-            if let Some(e) = self.trace_to_merge_depth(alt_start, start, depth) { ends.push(e); } else { return None; }
+            if let Some(e) = self.trace_to_merge_depth(alt_start, start, depth) {
+                ends.push(e);
+            } else {
+                return None;
+            }
         }
-        if ends.is_empty() { return None; }
+        if ends.is_empty() {
+            return None;
+        }
         let first = ends[0];
-        if ends.iter().all(|&e| e == first) { Some(first) } else { None }
+        if ends.iter().all(|&e| e == first) {
+            Some(first)
+        } else {
+            None
+        }
     }
 
-    fn trace_to_merge_depth(&self, start: StateId, alt_start: StateId, depth: usize) -> Option<StateId> {
-        if depth > 20 { return None; }
+    fn trace_to_merge_depth(
+        &self,
+        start: StateId,
+        alt_start: StateId,
+        depth: usize,
+    ) -> Option<StateId> {
+        if depth > 20 {
+            return None;
+        }
         let mut current = start;
         let mut visited = vec![false; self.nfa.states.len()];
         visited[alt_start as usize] = true;
         for _ in 0..200 {
-            if visited[current as usize] { return None; }
+            if visited[current as usize] {
+                return None;
+            }
             visited[current as usize] = true;
             let state = &self.nfa.states[current as usize];
-            if state.is_match { return Some(current); }
-            if let Some(NfaInstruction::CodepointClass(_, t)) = &state.instruction { current = *t; continue; }
-            if state.transitions.is_empty() && state.epsilon.is_empty() { return Some(current); }
-            if state.epsilon.len() == 1 && state.transitions.is_empty() { current = state.epsilon[0]; continue; }
-            if !state.transitions.is_empty() && state.epsilon.is_empty() { current = state.transitions[0].1; continue; }
-            if !state.transitions.is_empty() && state.epsilon.len() == 1 { current = state.transitions[0].1; continue; }
+            if state.is_match {
+                return Some(current);
+            }
+            if let Some(NfaInstruction::CodepointClass(_, t)) = &state.instruction {
+                current = *t;
+                continue;
+            }
+            if state.transitions.is_empty() && state.epsilon.is_empty() {
+                return Some(current);
+            }
+            if state.epsilon.len() == 1 && state.transitions.is_empty() {
+                current = state.epsilon[0];
+                continue;
+            }
+            if !state.transitions.is_empty() && state.epsilon.is_empty() {
+                current = state.transitions[0].1;
+                continue;
+            }
+            if !state.transitions.is_empty() && state.epsilon.len() == 1 {
+                current = state.transitions[0].1;
+                continue;
+            }
             if state.epsilon.len() >= 2 && state.transitions.is_empty() {
                 let mut fwd = Vec::new();
-                for &e in &state.epsilon { if !visited[e as usize] { fwd.push(e); } }
-                if fwd.len() == 1 { current = fwd[0]; continue; }
-                if let Some(ne) = self.find_alternation_end_depth(current, depth + 1) { current = ne; continue; }
+                for &e in &state.epsilon {
+                    if !visited[e as usize] {
+                        fwd.push(e);
+                    }
+                }
+                if fwd.len() == 1 {
+                    current = fwd[0];
+                    continue;
+                }
+                if let Some(ne) = self.find_alternation_end_depth(current, depth + 1) {
+                    current = ne;
+                    continue;
+                }
                 return None;
             }
             return None;
@@ -1598,11 +2092,16 @@ impl TaggedNfaJitCompiler {
     }
 
     fn is_trivial_path_depth(&self, start: StateId, end: StateId, depth: usize) -> bool {
-        if depth > 100 { return false; }
-        if start == end { return true; }
+        if depth > 100 {
+            return false;
+        }
+        if start == end {
+            return true;
+        }
         let state = &self.nfa.states[start as usize];
         if state.epsilon.len() == 1 && state.transitions.is_empty() {
-            return state.epsilon[0] == end || self.is_trivial_path_depth(state.epsilon[0], end, depth + 1);
+            return state.epsilon[0] == end
+                || self.is_trivial_path_depth(state.epsilon[0], end, depth + 1);
         }
         false
     }
@@ -1613,16 +2112,24 @@ impl TaggedNfaJitCompiler {
             let state = &self.nfa.states[current as usize];
             if !state.transitions.is_empty() {
                 let t = state.transitions[0].1;
-                if !state.transitions.iter().all(|(_, tt)| *tt == t) { return None; }
-                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                if !state.transitions.iter().all(|(_, tt)| *tt == t) {
+                    return None;
+                }
+                let ranges: Vec<ByteRange> =
+                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
                 return if ranges.len() == 1 && ranges[0].start == ranges[0].end {
                     Some(PatternStep::Byte(ranges[0].start))
                 } else {
                     Some(PatternStep::ByteClass(ByteClass::new(ranges)))
                 };
             }
-            if state.epsilon.len() == 1 && state.transitions.is_empty() { current = state.epsilon[0]; continue; }
-            if state.is_match || state.epsilon.len() > 1 { return None; }
+            if state.epsilon.len() == 1 && state.transitions.is_empty() {
+                current = state.epsilon[0];
+                continue;
+            }
+            if state.is_match || state.epsilon.len() > 1 {
+                return None;
+            }
             return None;
         }
     }
@@ -1631,20 +2138,50 @@ impl TaggedNfaJitCompiler {
         let mut current = state_id;
         loop {
             let state = &self.nfa.states[current as usize];
-            if !state.transitions.is_empty() { return state.transitions[0].1; }
-            if state.epsilon.len() == 1 { current = state.epsilon[0]; continue; }
+            if !state.transitions.is_empty() {
+                return state.transitions[0].1;
+            }
+            if state.epsilon.len() == 1 {
+                current = state.epsilon[0];
+                continue;
+            }
             return current;
         }
     }
 
-    fn finalize(self, find_offset: dynasmrt::AssemblyOffset, captures_offset: dynasmrt::AssemblyOffset, find_needs_ctx: bool, fallback_steps: Option<Vec<PatternStep>>) -> Result<TaggedNfaJit> {
-        let code = self.asm.finalize().map_err(|e| Error::new(ErrorKind::Jit(format!("Failed to finalize: {:?}", e)), ""))?;
-        let find_fn: extern "C" fn(*const u8, usize, *mut TaggedNfaContext) -> i64 = unsafe { std::mem::transmute(code.ptr(find_offset)) };
-        let captures_fn: extern "C" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64 = unsafe { std::mem::transmute(code.ptr(captures_offset)) };
+    fn finalize(
+        self,
+        find_offset: dynasmrt::AssemblyOffset,
+        captures_offset: dynasmrt::AssemblyOffset,
+        find_needs_ctx: bool,
+        fallback_steps: Option<Vec<PatternStep>>,
+    ) -> Result<TaggedNfaJit> {
+        let code = self
+            .asm
+            .finalize()
+            .map_err(|e| Error::new(ErrorKind::Jit(format!("Failed to finalize: {:?}", e)), ""))?;
+        let find_fn: extern "C" fn(*const u8, usize, *mut TaggedNfaContext) -> i64 =
+            unsafe { std::mem::transmute(code.ptr(find_offset)) };
+        let captures_fn: extern "C" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64 =
+            unsafe { std::mem::transmute(code.ptr(captures_offset)) };
         let capture_count = self.nfa.capture_count;
         let state_count = self.nfa.states.len();
         let lookaround_count = self.liveness.lookaround_count;
         let stride = (capture_count as usize + 1) * 2;
-        Ok(TaggedNfaJit::new(code, find_fn, captures_fn, self.liveness, self.nfa, capture_count, state_count, lookaround_count, stride, self.codepoint_classes, self.lookaround_nfas, find_needs_ctx, fallback_steps))
+        Ok(TaggedNfaJit::new(
+            code,
+            find_fn,
+            captures_fn,
+            self.liveness,
+            self.nfa,
+            capture_count,
+            state_count,
+            lookaround_count,
+            stride,
+            self.codepoint_classes,
+            self.lookaround_nfas,
+            find_needs_ctx,
+            fallback_steps,
+        ))
     }
 }

--- a/src/nfa/tagged/jit/helpers.rs
+++ b/src/nfa/tagged/jit/helpers.rs
@@ -134,7 +134,7 @@ unsafe fn check_codepoint_class_impl(
 /// - Positive value: The length of the UTF-8 character that matched (1-4 bytes)
 /// - 0 or negative: No match (or position out of bounds)
 #[allow(dead_code)]
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub unsafe extern "win64" fn check_codepoint_class(
     input_ptr: *const u8,
     pos: usize,
@@ -145,8 +145,19 @@ pub unsafe extern "win64" fn check_codepoint_class(
 }
 
 #[allow(dead_code)]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub unsafe extern "sysv64" fn check_codepoint_class(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    cpclass_ptr: *const CodepointClass,
+) -> i64 {
+    check_codepoint_class_impl(input_ptr, pos, input_len, cpclass_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(target_arch = "aarch64")]
+pub unsafe extern "C" fn check_codepoint_class(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
@@ -181,7 +192,7 @@ unsafe fn check_positive_lookahead_impl(
 
 /// Helper function callable from JIT code to evaluate a positive lookahead assertion.
 #[allow(dead_code)]
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub unsafe extern "win64" fn check_positive_lookahead(
     input_ptr: *const u8,
     pos: usize,
@@ -192,8 +203,19 @@ pub unsafe extern "win64" fn check_positive_lookahead(
 }
 
 #[allow(dead_code)]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub unsafe extern "sysv64" fn check_positive_lookahead(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_positive_lookahead_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(target_arch = "aarch64")]
+pub unsafe extern "C" fn check_positive_lookahead(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
@@ -228,7 +250,7 @@ unsafe fn check_negative_lookahead_impl(
 
 /// Helper function callable from JIT code to evaluate a negative lookahead assertion.
 #[allow(dead_code)]
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub unsafe extern "win64" fn check_negative_lookahead(
     input_ptr: *const u8,
     pos: usize,
@@ -239,8 +261,19 @@ pub unsafe extern "win64" fn check_negative_lookahead(
 }
 
 #[allow(dead_code)]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub unsafe extern "sysv64" fn check_negative_lookahead(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_negative_lookahead_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(target_arch = "aarch64")]
+pub unsafe extern "C" fn check_negative_lookahead(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
@@ -275,7 +308,7 @@ unsafe fn check_positive_lookbehind_impl(
 
 /// Helper function callable from JIT code to evaluate a positive lookbehind assertion.
 #[allow(dead_code)]
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub unsafe extern "win64" fn check_positive_lookbehind(
     input_ptr: *const u8,
     pos: usize,
@@ -286,8 +319,19 @@ pub unsafe extern "win64" fn check_positive_lookbehind(
 }
 
 #[allow(dead_code)]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub unsafe extern "sysv64" fn check_positive_lookbehind(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_positive_lookbehind_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(target_arch = "aarch64")]
+pub unsafe extern "C" fn check_positive_lookbehind(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
@@ -322,7 +366,7 @@ unsafe fn check_negative_lookbehind_impl(
 
 /// Helper function callable from JIT code to evaluate a negative lookbehind assertion.
 #[allow(dead_code)]
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 pub unsafe extern "win64" fn check_negative_lookbehind(
     input_ptr: *const u8,
     pos: usize,
@@ -333,8 +377,19 @@ pub unsafe extern "win64" fn check_negative_lookbehind(
 }
 
 #[allow(dead_code)]
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 pub unsafe extern "sysv64" fn check_negative_lookbehind(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_negative_lookbehind_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(target_arch = "aarch64")]
+pub unsafe extern "C" fn check_negative_lookbehind(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,

--- a/src/nfa/tagged/jit/helpers.rs
+++ b/src/nfa/tagged/jit/helpers.rs
@@ -46,19 +46,9 @@ pub struct JitContext {
     pub max_threads: usize,
 }
 
-/// Helper function callable from JIT code to check if a UTF-8 character matches a CodepointClass.
-///
-/// Arguments:
-/// - `input_ptr`: Pointer to the start of the input string
-/// - `pos`: Current position in the input
-/// - `input_len`: Total length of the input
-/// - `cpclass_ptr`: Pointer to the CodepointClass struct
-///
-/// Returns:
-/// - Positive value: The length of the UTF-8 character that matched (1-4 bytes)
-/// - 0 or negative: No match (or position out of bounds)
-#[allow(dead_code)]
-pub unsafe extern "sysv64" fn check_codepoint_class(
+// Implementation for check_codepoint_class (shared by both ABIs)
+#[inline]
+unsafe fn check_codepoint_class_impl(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
@@ -132,19 +122,42 @@ pub unsafe extern "sysv64" fn check_codepoint_class(
     }
 }
 
-/// Helper function callable from JIT code to evaluate a positive lookahead assertion.
+/// Helper function callable from JIT code to check if a UTF-8 character matches a CodepointClass.
 ///
 /// Arguments:
 /// - `input_ptr`: Pointer to the start of the input string
 /// - `pos`: Current position in the input
 /// - `input_len`: Total length of the input
-/// - `nfa_ptr`: Pointer to the inner NFA for the lookahead
+/// - `cpclass_ptr`: Pointer to the CodepointClass struct
 ///
 /// Returns:
-/// - 1 if the lookahead matches (pattern found at position)
-/// - 0 if the lookahead does not match
+/// - Positive value: The length of the UTF-8 character that matched (1-4 bytes)
+/// - 0 or negative: No match (or position out of bounds)
 #[allow(dead_code)]
-pub unsafe extern "sysv64" fn check_positive_lookahead(
+#[cfg(target_os = "windows")]
+pub unsafe extern "win64" fn check_codepoint_class(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    cpclass_ptr: *const CodepointClass,
+) -> i64 {
+    check_codepoint_class_impl(input_ptr, pos, input_len, cpclass_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "sysv64" fn check_codepoint_class(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    cpclass_ptr: *const CodepointClass,
+) -> i64 {
+    check_codepoint_class_impl(input_ptr, pos, input_len, cpclass_ptr)
+}
+
+// Implementation for check_positive_lookahead (shared by both ABIs)
+#[inline]
+unsafe fn check_positive_lookahead_impl(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
@@ -158,7 +171,6 @@ pub unsafe extern "sysv64" fn check_positive_lookahead(
     let input = std::slice::from_raw_parts(input_ptr, input_len);
     let remaining = &input[pos..];
 
-    // Use PikeVM to check if the pattern matches at the current position
     let vm = crate::vm::PikeVm::new(nfa.clone());
     if vm.is_match(remaining) {
         1
@@ -167,54 +179,79 @@ pub unsafe extern "sysv64" fn check_positive_lookahead(
     }
 }
 
-/// Helper function callable from JIT code to evaluate a negative lookahead assertion.
-///
-/// Arguments:
-/// - `input_ptr`: Pointer to the start of the input string
-/// - `pos`: Current position in the input
-/// - `input_len`: Total length of the input
-/// - `nfa_ptr`: Pointer to the inner NFA for the lookahead
-///
-/// Returns:
-/// - 1 if the lookahead succeeds (pattern NOT found at position)
-/// - 0 if the lookahead fails (pattern was found)
+/// Helper function callable from JIT code to evaluate a positive lookahead assertion.
 #[allow(dead_code)]
-pub unsafe extern "sysv64" fn check_negative_lookahead(
+#[cfg(target_os = "windows")]
+pub unsafe extern "win64" fn check_positive_lookahead(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_positive_lookahead_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "sysv64" fn check_positive_lookahead(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_positive_lookahead_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+// Implementation for check_negative_lookahead (shared by both ABIs)
+#[inline]
+unsafe fn check_negative_lookahead_impl(
     input_ptr: *const u8,
     pos: usize,
     input_len: usize,
     nfa_ptr: *const Nfa,
 ) -> i64 {
     if pos > input_len {
-        return 1; // At invalid position, negative lookahead succeeds
+        return 1;
     }
 
     let nfa = &*nfa_ptr;
     let input = std::slice::from_raw_parts(input_ptr, input_len);
     let remaining = &input[pos..];
 
-    // Use PikeVM to check if the pattern matches at the current position
     let vm = crate::vm::PikeVm::new(nfa.clone());
     if vm.is_match(remaining) {
-        0 // Pattern matched, negative lookahead fails
+        0
     } else {
-        1 // Pattern didn't match, negative lookahead succeeds
+        1
     }
 }
 
-/// Helper function callable from JIT code to evaluate a positive lookbehind assertion.
-///
-/// Arguments:
-/// - `input_ptr`: Pointer to the start of the input string
-/// - `pos`: Current position in the input
-/// - `input_len`: Total length of the input (unused but kept for ABI consistency)
-/// - `nfa_ptr`: Pointer to the inner NFA for the lookbehind
-///
-/// Returns:
-/// - 1 if the lookbehind matches (pattern found ending at position)
-/// - 0 if the lookbehind does not match
+/// Helper function callable from JIT code to evaluate a negative lookahead assertion.
 #[allow(dead_code)]
-pub unsafe extern "sysv64" fn check_positive_lookbehind(
+#[cfg(target_os = "windows")]
+pub unsafe extern "win64" fn check_negative_lookahead(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_negative_lookahead_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "sysv64" fn check_negative_lookahead(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_negative_lookahead_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+// Implementation for check_positive_lookbehind (shared by both ABIs)
+#[inline]
+unsafe fn check_positive_lookbehind_impl(
     input_ptr: *const u8,
     pos: usize,
     _input_len: usize,
@@ -223,13 +260,10 @@ pub unsafe extern "sysv64" fn check_positive_lookbehind(
     let nfa = &*nfa_ptr;
     let input = std::slice::from_raw_parts(input_ptr, pos);
 
-    // Use PikeVM to check if the pattern matches ending at the current position
     let vm = crate::vm::PikeVm::new(nfa.clone());
 
-    // Try all possible start positions before current position
     for lookback_start in 0..=pos {
         let slice = &input[lookback_start..];
-        // Check if pattern matches the entire slice (anchored match)
         if let Some((s, e)) = vm.find(slice) {
             if s == 0 && e == slice.len() {
                 return 1;
@@ -239,19 +273,32 @@ pub unsafe extern "sysv64" fn check_positive_lookbehind(
     0
 }
 
-/// Helper function callable from JIT code to evaluate a negative lookbehind assertion.
-///
-/// Arguments:
-/// - `input_ptr`: Pointer to the start of the input string
-/// - `pos`: Current position in the input
-/// - `input_len`: Total length of the input (unused but kept for ABI consistency)
-/// - `nfa_ptr`: Pointer to the inner NFA for the lookbehind
-///
-/// Returns:
-/// - 1 if the lookbehind succeeds (pattern NOT found ending at position)
-/// - 0 if the lookbehind fails (pattern was found ending at position)
+/// Helper function callable from JIT code to evaluate a positive lookbehind assertion.
 #[allow(dead_code)]
-pub unsafe extern "sysv64" fn check_negative_lookbehind(
+#[cfg(target_os = "windows")]
+pub unsafe extern "win64" fn check_positive_lookbehind(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_positive_lookbehind_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "sysv64" fn check_positive_lookbehind(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_positive_lookbehind_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+// Implementation for check_negative_lookbehind (shared by both ABIs)
+#[inline]
+unsafe fn check_negative_lookbehind_impl(
     input_ptr: *const u8,
     pos: usize,
     _input_len: usize,
@@ -260,18 +307,38 @@ pub unsafe extern "sysv64" fn check_negative_lookbehind(
     let nfa = &*nfa_ptr;
     let input = std::slice::from_raw_parts(input_ptr, pos);
 
-    // Use PikeVM to check if the pattern matches ending at the current position
     let vm = crate::vm::PikeVm::new(nfa.clone());
 
-    // Try all possible start positions before current position
     for lookback_start in 0..=pos {
         let slice = &input[lookback_start..];
-        // Check if pattern matches the entire slice (anchored match)
         if let Some((s, e)) = vm.find(slice) {
             if s == 0 && e == slice.len() {
-                return 0; // Pattern found, negative lookbehind fails
+                return 0;
             }
         }
     }
-    1 // Pattern not found, negative lookbehind succeeds
+    1
+}
+
+/// Helper function callable from JIT code to evaluate a negative lookbehind assertion.
+#[allow(dead_code)]
+#[cfg(target_os = "windows")]
+pub unsafe extern "win64" fn check_negative_lookbehind(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_negative_lookbehind_impl(input_ptr, pos, input_len, nfa_ptr)
+}
+
+#[allow(dead_code)]
+#[cfg(not(target_os = "windows"))]
+pub unsafe extern "sysv64" fn check_negative_lookbehind(
+    input_ptr: *const u8,
+    pos: usize,
+    input_len: usize,
+    nfa_ptr: *const Nfa,
+) -> i64 {
+    check_negative_lookbehind_impl(input_ptr, pos, input_len, nfa_ptr)
 }

--- a/src/nfa/tagged/jit/jit.rs
+++ b/src/nfa/tagged/jit/jit.rs
@@ -69,11 +69,11 @@ pub struct TaggedNfaJit {
     stride: usize,
     /// Stored CodepointClasses for JIT code to reference.
     /// These must outlive the JIT code since their pointers are embedded in the generated assembly.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::vec_box)]
     codepoint_classes: Vec<Box<CodepointClass>>,
     /// Stored lookaround NFAs for JIT code to reference via helper functions.
     /// Index corresponds to the index stored in PatternStep::*Lookahead/*Lookbehind.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::vec_box)]
     lookaround_nfas: Vec<Box<Nfa>>,
     /// Whether find_fn needs context (false for simple patterns).
     /// When false, we skip the expensive context setup in find().
@@ -95,7 +95,7 @@ pub struct TaggedNfaJit {
 
 impl TaggedNfaJit {
     /// Creates a new TaggedNfaJit from compiled components.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::vec_box)]
     pub(super) fn new(
         code: ExecutableBuffer,
         find_fn: FindFn,
@@ -162,6 +162,7 @@ impl TaggedNfaJit {
                 let ns = t0.elapsed().as_nanos() as u64;
                 TOTAL_NS.fetch_add(ns, std::sync::atomic::Ordering::Relaxed);
                 let count = CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                #[allow(clippy::manual_is_multiple_of)]
                 if count % 10000 == 0 {
                     let total = TOTAL_NS.load(std::sync::atomic::Ordering::Relaxed);
                     eprintln!(

--- a/src/nfa/tagged/jit/jit.rs
+++ b/src/nfa/tagged/jit/jit.rs
@@ -11,7 +11,12 @@ use crate::vm::{PikeVm, PikeVmContext};
 use super::super::{
     analyze_liveness, LookaroundCache, NfaLiveness, PatternStep, TaggedNfa, TaggedNfaContext,
 };
+
+#[cfg(target_arch = "x86_64")]
 use super::x86_64::TaggedNfaJitCompiler;
+
+#[cfg(target_arch = "aarch64")]
+use super::aarch64::TaggedNfaJitCompiler;
 
 use dynasmrt::ExecutableBuffer;
 
@@ -19,17 +24,25 @@ use dynasmrt::ExecutableBuffer;
 pub const JIT_USE_INTERPRETER: i64 = -2;
 
 // Platform-specific function pointer types for JIT code
-#[cfg(target_os = "windows")]
+// x86_64 Windows uses Microsoft x64 ABI
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 type FindFn = unsafe extern "win64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64;
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 type CapturesFn =
     unsafe extern "win64" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64;
 
-#[cfg(not(target_os = "windows"))]
+// x86_64 Unix uses System V AMD64 ABI
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 type FindFn = unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 type CapturesFn =
     unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64;
+
+// ARM64 uses AAPCS64 on all platforms (extern "C")
+#[cfg(target_arch = "aarch64")]
+type FindFn = unsafe extern "C" fn(*const u8, usize, *mut TaggedNfaContext) -> i64;
+#[cfg(target_arch = "aarch64")]
+type CapturesFn = unsafe extern "C" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64;
 
 /// A JIT-compiled Tagged NFA for single-pass capture extraction.
 pub struct TaggedNfaJit {

--- a/src/nfa/tagged/jit/jit.rs
+++ b/src/nfa/tagged/jit/jit.rs
@@ -18,17 +18,29 @@ use dynasmrt::ExecutableBuffer;
 /// Sentinel value returned by JIT code to indicate interpreter fallback.
 pub const JIT_USE_INTERPRETER: i64 = -2;
 
+// Platform-specific function pointer types for JIT code
+#[cfg(target_os = "windows")]
+type FindFn = unsafe extern "win64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64;
+#[cfg(target_os = "windows")]
+type CapturesFn =
+    unsafe extern "win64" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64;
+
+#[cfg(not(target_os = "windows"))]
+type FindFn = unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64;
+#[cfg(not(target_os = "windows"))]
+type CapturesFn =
+    unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64;
+
 /// A JIT-compiled Tagged NFA for single-pass capture extraction.
 pub struct TaggedNfaJit {
     /// Executable buffer containing the JIT code.
     #[allow(dead_code)]
     code: ExecutableBuffer,
     /// Entry point for `find` (returns end position or -1, or -2 for interpreter fallback).
-    find_fn: unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64,
+    find_fn: FindFn,
     /// Entry point for `captures` (writes to captures_out buffer, returns match end or -1/-2).
     /// Arguments: input_ptr, input_len, ctx, captures_out
-    captures_fn:
-        unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext, *mut i64) -> i64,
+    captures_fn: CapturesFn,
     /// Liveness analysis for sparse copying.
     liveness: NfaLiveness,
     /// The NFA (kept for reference, PikeVm is used for fallback).
@@ -73,13 +85,8 @@ impl TaggedNfaJit {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         code: ExecutableBuffer,
-        find_fn: unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64,
-        captures_fn: unsafe extern "sysv64" fn(
-            *const u8,
-            usize,
-            *mut TaggedNfaContext,
-            *mut i64,
-        ) -> i64,
+        find_fn: FindFn,
+        captures_fn: CapturesFn,
         liveness: NfaLiveness,
         nfa: Nfa,
         capture_count: u32,

--- a/src/nfa/tagged/jit/mod.rs
+++ b/src/nfa/tagged/jit/mod.rs
@@ -23,6 +23,7 @@
 //! - `helpers.rs` - JIT context and extern helper functions
 
 mod helpers;
+#[allow(clippy::module_inception)]
 mod jit;
 
 #[cfg(target_arch = "x86_64")]

--- a/src/nfa/tagged/jit/mod.rs
+++ b/src/nfa/tagged/jit/mod.rs
@@ -1,24 +1,35 @@
 //! JIT compilation for Tagged NFA execution.
 //!
 //! This module provides JIT-compiled execution for Tagged NFA patterns.
-//! It is feature-gated behind `#[cfg(all(feature = "jit", target_arch = "x86_64"))]`.
+//! It is feature-gated behind `#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]`.
 //!
 //! # Architecture
 //!
-//! The JIT compiler generates x86-64 code that mirrors the TaggedNfaInterpreter:
+//! The JIT compiler generates native code that mirrors the TaggedNfaInterpreter:
 //! - Same algorithm, same semantics
 //! - Uses Structure-of-Arrays (SoA) layout for cache efficiency
 //! - Sparse capture copying based on liveness analysis
+//!
+//! # Architecture Support
+//!
+//! - **x86_64**: Uses dynasm for code generation
+//! - **aarch64**: Uses dynasm for code generation
 //!
 //! # Module Organization
 //!
 //! - `jit.rs` - TaggedNfaJit struct and public API
 //! - `x86_64.rs` - dynasm-based x86-64 code generation
+//! - `aarch64.rs` - dynasm-based ARM64 code generation
 //! - `helpers.rs` - JIT context and extern helper functions
 
 mod helpers;
 mod jit;
+
+#[cfg(target_arch = "x86_64")]
 mod x86_64;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 
 pub use helpers::JitContext;
 pub use jit::{compile_tagged_nfa, compile_tagged_nfa_with_liveness, TaggedNfaJit};

--- a/src/nfa/tagged/jit/x86_64.rs
+++ b/src/nfa/tagged/jit/x86_64.rs
@@ -39,9 +39,11 @@ pub(super) struct TaggedNfaJitCompiler {
     add_thread_label: dynasmrt::DynamicLabel,
     /// CodepointClasses collected during pattern extraction.
     /// Boxed to ensure stable addresses for JIT code references.
+    #[allow(clippy::vec_box)]
     codepoint_classes: Vec<Box<CodepointClass>>,
     /// Lookaround NFAs collected during pattern extraction.
     /// Boxed to ensure stable addresses for JIT helper function references.
+    #[allow(clippy::vec_box)]
     lookaround_nfas: Vec<Box<Nfa>>,
 }
 
@@ -176,21 +178,22 @@ impl TaggedNfaJitCompiler {
         self.finalize(find_offset, captures_offset, false, steps)
     }
 
-    /// Generates JIT code for simple linear patterns (literals).
-    ///
-    /// For a pattern like "abc", generates code that:
-    /// 1. Tries each starting position
-    /// 2. At each position, walks the linear NFA chain
-    /// 3. Returns on first match
-    ///
-    /// Register allocation (System V AMD64 ABI):
-    /// - rdi = input_ptr (argument, then scratch)
-    /// - rsi = input_len (argument)
-    /// - rbx = input_ptr (callee-saved)
-    /// - r12 = input_len (callee-saved)
-    /// - r13 = start_pos for current attempt (callee-saved)
-    /// - r14 = current_pos (absolute position in input) (callee-saved)
-    /// - rax = scratch / return value
+    // Generates JIT code for simple linear patterns (literals).
+    //
+    // For a pattern like "abc", generates code that:
+    // 1. Tries each starting position
+    // 2. At each position, walks the linear NFA chain
+    // 3. Returns on first match
+    //
+    // Register allocation (System V AMD64 ABI):
+    // - rdi = input_ptr (argument, then scratch)
+    // - rsi = input_len (argument)
+    // - rbx = input_ptr (callee-saved)
+    // - r12 = input_len (callee-saved)
+    // - r13 = start_pos for current attempt (callee-saved)
+    // - r14 = current_pos (absolute position in input) (callee-saved)
+    // - rax = scratch / return value
+
     /// Check if pattern contains backreferences (recursively in alternations).
     fn has_backref(steps: &[PatternStep]) -> bool {
         steps.iter().any(|s| match s {
@@ -252,7 +255,7 @@ impl TaggedNfaJitCompiler {
                 // Consumes input if any alternative consumes input
                 alternatives
                     .iter()
-                    .any(|alt| alt.iter().any(|s| Self::step_consumes_input(s)))
+                    .any(|alt| alt.iter().any(Self::step_consumes_input))
             }
 
             // Zero-width assertions don't consume input
@@ -402,7 +405,7 @@ impl TaggedNfaJitCompiler {
                 PatternStep::GreedyPlus(byte_class) => {
                     // Check if there are remaining steps that consume input
                     let remaining = &steps[step_idx + 1..];
-                    let needs_backtrack = remaining.iter().any(|s| Self::step_consumes_input(s));
+                    let needs_backtrack = remaining.iter().any(Self::step_consumes_input);
 
                     if needs_backtrack {
                         // Backtracking version: greedily match, then try remaining, backtrack on failure
@@ -445,7 +448,7 @@ impl TaggedNfaJitCompiler {
                 PatternStep::GreedyStar(byte_class) => {
                     // Check if there are remaining steps that consume input
                     let remaining = &steps[step_idx + 1..];
-                    let needs_backtrack = remaining.iter().any(|s| Self::step_consumes_input(s));
+                    let needs_backtrack = remaining.iter().any(Self::step_consumes_input);
 
                     if needs_backtrack {
                         // Backtracking version
@@ -578,7 +581,7 @@ impl TaggedNfaJitCompiler {
                 PatternStep::GreedyCodepointPlus(cpclass) => {
                     // Check if there are remaining steps that consume input
                     let remaining = &steps[step_idx + 1..];
-                    let needs_backtrack = remaining.iter().any(|s| Self::step_consumes_input(s));
+                    let needs_backtrack = remaining.iter().any(Self::step_consumes_input);
 
                     if needs_backtrack {
                         // Backtracking version: greedily match UTF-8, then try remaining, backtrack on failure
@@ -1075,13 +1078,8 @@ impl TaggedNfaJitCompiler {
             let is_last = alt_idx == alternatives.len() - 1;
 
             // Create label for trying next alternative (or cleanup for last)
-            let try_next_alt = if is_last {
-                // Last alternative - if it fails, we need to clean up and fail
-                let cleanup_label = self.asm.new_dynamic_label();
-                cleanup_label
-            } else {
-                self.asm.new_dynamic_label()
-            };
+            // Last alternative - if it fails, we need to clean up and fail
+            let try_next_alt = self.asm.new_dynamic_label();
 
             // Emit code for each step in this alternative
             for alt_step in alt_steps.iter() {
@@ -4643,8 +4641,6 @@ impl TaggedNfaJitCompiler {
         visited: &mut [bool],
         end_state: Option<StateId>,
     ) -> Vec<PatternStep> {
-        use crate::nfa::NfaInstruction;
-
         let mut steps = Vec::new();
         let mut current = start;
 
@@ -4786,8 +4782,7 @@ impl TaggedNfaJitCompiler {
                 }
 
                 // Extract the ranges for this step
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 // Check if target state forms a loop (greedy or non-greedy)
                 let target_state = &self.nfa.states[target as usize];
@@ -4882,11 +4877,8 @@ impl TaggedNfaJitCompiler {
                                 pattern_state.transitions.iter().all(|(_, t)| *t == target);
 
                             if all_same_target {
-                                let ranges: Vec<ByteRange> = pattern_state
-                                    .transitions
-                                    .iter()
-                                    .map(|(r, _)| r.clone())
-                                    .collect();
+                                let ranges: Vec<ByteRange> =
+                                    pattern_state.transitions.iter().map(|(r, _)| *r).collect();
 
                                 // Find the exit state (after the NonGreedyExit marker)
                                 let exit_state = eps0_state.epsilon[0];
@@ -4992,8 +4984,7 @@ impl TaggedNfaJitCompiler {
                     return Vec::new(); // Different targets
                 }
 
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 // Check for greedy plus pattern: current -[byte]-> target -[eps]-> current (loop back)
                 //                                              |-> next (exit)
@@ -5112,11 +5103,7 @@ impl TaggedNfaJitCompiler {
             return None;
         }
 
-        let ranges: Vec<ByteRange> = loop_state
-            .transitions
-            .iter()
-            .map(|(r, _)| r.clone())
-            .collect();
+        let ranges: Vec<ByteRange> = loop_state.transitions.iter().map(|(r, _)| *r).collect();
 
         // The target should have epsilon back to branch_state (completing the loop)
         let target_state = &inner_nfa.states[target as usize];
@@ -5202,8 +5189,6 @@ impl TaggedNfaJitCompiler {
         alt_start: StateId,
         depth: usize,
     ) -> Option<StateId> {
-        use crate::nfa::NfaInstruction;
-
         // Limit recursion depth to prevent stack overflow
         if depth > 20 {
             return None;
@@ -5329,8 +5314,7 @@ impl TaggedNfaJitCompiler {
                     return None;
                 }
 
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 return if ranges.len() == 1 && ranges[0].start == ranges[0].end {
                     Some(PatternStep::Byte(ranges[0].start))

--- a/src/nfa/tagged/jit/x86_64.rs
+++ b/src/nfa/tagged/jit/x86_64.rs
@@ -321,7 +321,22 @@ impl TaggedNfaJitCompiler {
             return self.finalize(find_offset, captures_offset, true, None);
         }
 
-        // Prologue
+        // Prologue - save callee-saved registers
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; push rdi          // Callee-saved on Windows
+            ; push rsi          // Callee-saved on Windows
+            ; push rbx
+            ; push r12
+            ; push r13
+            ; push r14
+            ; push r15
+            // Windows: args in RCX, RDX -> move to RDI, RSI for internal use
+            ; mov rdi, rcx
+            ; mov rsi, rdx
+        );
+
+        #[cfg(not(target_os = "windows"))]
         dynasm!(self.asm
             ; push rbx
             ; push r12
@@ -331,7 +346,7 @@ impl TaggedNfaJitCompiler {
         );
 
         // Set up registers
-        // rdi = input_ptr, rsi = input_len, rdx = ctx (unused)
+        // rdi = input_ptr, rsi = input_len (after platform-specific setup)
         dynasm!(self.asm
             ; mov rbx, rdi      // rbx = input_ptr
             ; mov r12, rsi      // r12 = input_len
@@ -890,8 +905,22 @@ impl TaggedNfaJitCompiler {
             ; mov rax, r13
             ; shl rax, 32               // rax = start << 32
             ; or rax, r14               // rax = (start << 32) | end
+        );
 
-            // Epilogue
+        // Epilogue - restore callee-saved registers
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
+            ; pop rbx
+            ; pop rsi
+            ; pop rdi
+            ; ret
+        );
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.asm
             ; pop r15
             ; pop r14
             ; pop r13
@@ -904,8 +933,22 @@ impl TaggedNfaJitCompiler {
         dynasm!(self.asm
             ; =>no_match
             ; mov rax, -1i32
+        );
 
-            // Epilogue
+        // Epilogue - restore callee-saved registers
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
+            ; pop rbx
+            ; pop rsi
+            ; pop rdi
+            ; ret
+        );
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.asm
             ; pop r15
             ; pop r14
             ; pop r13
@@ -3609,7 +3652,14 @@ impl TaggedNfaJitCompiler {
         self.codepoint_classes.push(cpclass_box);
 
         // Helper function that checks membership
-        // Must use extern "sysv64" for System V AMD64 ABI
+        // Use platform-specific calling convention
+        #[cfg(target_os = "windows")]
+        extern "win64" fn check_membership(codepoint: u32, cpclass: *const CodepointClass) -> bool {
+            let cpclass = unsafe { &*cpclass };
+            cpclass.contains(codepoint)
+        }
+
+        #[cfg(not(target_os = "windows"))]
         extern "sysv64" fn check_membership(
             codepoint: u32,
             cpclass: *const CodepointClass,
@@ -3618,13 +3668,40 @@ impl TaggedNfaJitCompiler {
             cpclass.contains(codepoint)
         }
 
-        let check_fn: extern "sysv64" fn(u32, *const CodepointClass) -> bool = check_membership;
-        let check_fn_ptr = check_fn as usize as i64;
+        #[cfg(target_os = "windows")]
+        let check_fn_ptr = {
+            let check_fn: extern "win64" fn(u32, *const CodepointClass) -> bool = check_membership;
+            check_fn as usize as i64
+        };
 
-        // Call the helper function
-        // System V ABI: rdi = first arg (codepoint), rsi = second arg (cpclass ptr)
+        #[cfg(not(target_os = "windows"))]
+        let check_fn_ptr = {
+            let check_fn: extern "sysv64" fn(u32, *const CodepointClass) -> bool = check_membership;
+            check_fn as usize as i64
+        };
+
+        // Call the helper function with platform-specific calling convention
+        #[cfg(target_os = "windows")]
         dynasm!(self.asm
             // eax already contains codepoint
+            // Windows x64: args in RCX, RDX
+            ; mov ecx, eax                    // rcx = codepoint (zero-extended)
+            ; mov rdx, QWORD cpclass_ptr as i64  // rdx = cpclass pointer
+            ; sub rsp, 32                     // Shadow space
+            ; mov rax, QWORD check_fn_ptr     // Load function pointer
+            ; call rax                        // Call check_membership
+            ; add rsp, 32                     // Restore stack
+
+            // rax (al) = result: true (1) if in class, false (0) if not
+            ; test al, al
+            ; jz =>fail_label                 // If false, jump to fail
+            ; jmp =>check_done
+        );
+
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.asm
+            // eax already contains codepoint
+            // System V ABI: args in RDI, RSI
             ; mov edi, eax                    // rdi = codepoint (zero-extended)
             ; mov rsi, QWORD cpclass_ptr as i64  // rsi = cpclass pointer
             ; mov rax, QWORD check_fn_ptr     // Load function pointer
@@ -3857,19 +3934,32 @@ impl TaggedNfaJitCompiler {
 
         // Prologue - save callee-saved registers
         // On function entry: RSP is 8-mod-16 (return address pushed)
-        // 5 pushes = 40 bytes -> RSP is (8+40) = 48 = 0 mod 16 -> aligned!
-        // No sub rsp needed for alignment
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; push rdi          // Callee-saved on Windows
+            ; push rsi          // Callee-saved on Windows
+            ; push rbx
+            ; push r12
+            ; push r13
+            ; push r14
+            ; push r15
+            // Windows x64: args in RCX, RDX, R8, R9
+            // RCX=input_ptr, RDX=input_len, R8=ctx (unused), R9=captures_out
+            ; mov rbx, rcx      // rbx = input_ptr
+            ; mov r12, rdx      // r12 = input_len
+            ; mov r15, r9       // r15 = captures_out pointer
+            ; xor r13d, r13d    // r13 = start_pos = 0
+        );
+
+        #[cfg(not(target_os = "windows"))]
         dynasm!(self.asm
             ; push rbx
             ; push r12
             ; push r13
             ; push r14
             ; push r15
-        );
-
-        // Set up registers
-        // rdi = input_ptr, rsi = input_len, rdx = ctx (unused), rcx = captures_out
-        dynasm!(self.asm
+            // System V AMD64: args in RDI, RSI, RDX, RCX
+            // rdi = input_ptr, rsi = input_len, rdx = ctx (unused), rcx = captures_out
             ; mov rbx, rdi      // rbx = input_ptr
             ; mov r12, rsi      // r12 = input_len
             ; mov r15, rcx      // r15 = captures_out pointer
@@ -3945,6 +4035,22 @@ impl TaggedNfaJitCompiler {
             ; mov rax, r13
             ; shl rax, 32
             ; or rax, r14
+        );
+
+        // Epilogue - restore callee-saved registers
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
+            ; pop rbx
+            ; pop rsi
+            ; pop rdi
+            ; ret
+        );
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.asm
             ; pop r15
             ; pop r14
             ; pop r13
@@ -3957,6 +4063,22 @@ impl TaggedNfaJitCompiler {
         dynasm!(self.asm
             ; =>no_match
             ; mov rax, -1i32
+        );
+
+        // Epilogue - restore callee-saved registers
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
+            ; pop rbx
+            ; pop rsi
+            ; pop rdi
+            ; ret
+        );
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.asm
             ; pop r15
             ; pop r14
             ; pop r13
@@ -5272,10 +5394,30 @@ impl TaggedNfaJitCompiler {
             )
         })?;
 
-        // Get function pointers
-        let find_fn: unsafe extern "sysv64" fn(*const u8, usize, *mut TaggedNfaContext) -> i64 =
-            unsafe { std::mem::transmute(code.ptr(find_offset)) };
+        // Get function pointers with platform-specific calling convention
+        #[cfg(target_os = "windows")]
+        let find_fn: unsafe extern "win64" fn(
+            *const u8,
+            usize,
+            *mut TaggedNfaContext,
+        ) -> i64 = unsafe { std::mem::transmute(code.ptr(find_offset)) };
 
+        #[cfg(not(target_os = "windows"))]
+        let find_fn: unsafe extern "sysv64" fn(
+            *const u8,
+            usize,
+            *mut TaggedNfaContext,
+        ) -> i64 = unsafe { std::mem::transmute(code.ptr(find_offset)) };
+
+        #[cfg(target_os = "windows")]
+        let captures_fn: unsafe extern "win64" fn(
+            *const u8,
+            usize,
+            *mut TaggedNfaContext,
+            *mut i64,
+        ) -> i64 = unsafe { std::mem::transmute(code.ptr(captures_offset)) };
+
+        #[cfg(not(target_os = "windows"))]
         let captures_fn: unsafe extern "sysv64" fn(
             *const u8,
             usize,

--- a/src/nfa/tagged/liveness.rs
+++ b/src/nfa/tagged/liveness.rs
@@ -6,8 +6,8 @@
 //!
 //! The analysis uses backward dataflow:
 //! - A capture is live at state S if it may be read on any path from S to a match
-//! - live_reads[S] = reads_at[S] ∪ (∪ live_reads[successors(S)])
-//! - copy_mask[S] = live_reads[S] ∩ writes_before[S]
+//! - `live_reads[S] = reads_at[S] ∪ (∪ live_reads[successors(S)])`
+//! - `copy_mask[S] = live_reads[S] ∩ writes_before[S]`
 
 use crate::nfa::{Nfa, NfaInstruction, StateId};
 use std::collections::VecDeque;

--- a/src/nfa/tagged/mod.rs
+++ b/src/nfa/tagged/mod.rs
@@ -18,7 +18,7 @@ pub mod liveness;
 pub mod shared;
 pub mod steps;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod jit;
 
 // Re-export commonly used types

--- a/src/nfa/tagged/shared.rs
+++ b/src/nfa/tagged/shared.rs
@@ -44,7 +44,7 @@ impl ThreadWorklist {
     /// * `state_count` - Number of NFA states (for visited bitmap sizing)
     pub fn new(capture_count: u32, state_count: usize) -> Self {
         let stride = (capture_count as usize + 1) * 2;
-        let bitmap_words = (state_count.max(1) + 63) / 64;
+        let bitmap_words = state_count.max(1).div_ceil(64);
 
         Self {
             count: 0,
@@ -157,7 +157,7 @@ pub struct LookaroundCache {
 impl LookaroundCache {
     /// Creates a new cache for the given number of lookarounds and input length.
     pub fn new(lookaround_count: usize, max_input_len: usize) -> Self {
-        let words_needed = (max_input_len + 63) / 64;
+        let words_needed = max_input_len.div_ceil(64);
         let total_words = lookaround_count * words_needed;
         Self {
             count: lookaround_count,
@@ -174,7 +174,7 @@ impl LookaroundCache {
         if lookaround_id >= self.count || pos >= self.max_len {
             return false;
         }
-        let words_per_la = (self.max_len + 63) / 64;
+        let words_per_la = self.max_len.div_ceil(64);
         let word_idx = lookaround_id * words_per_la + pos / 64;
         let bit = pos % 64;
         (self.computed[word_idx] & (1u64 << bit)) != 0
@@ -187,7 +187,7 @@ impl LookaroundCache {
         if lookaround_id >= self.count || pos >= self.max_len {
             return false;
         }
-        let words_per_la = (self.max_len + 63) / 64;
+        let words_per_la = self.max_len.div_ceil(64);
         let word_idx = lookaround_id * words_per_la + pos / 64;
         let bit = pos % 64;
         (self.results[word_idx] & (1u64 << bit)) != 0
@@ -200,7 +200,7 @@ impl LookaroundCache {
         if lookaround_id >= self.count || pos >= self.max_len {
             return;
         }
-        let words_per_la = (self.max_len + 63) / 64;
+        let words_per_la = self.max_len.div_ceil(64);
         let word_idx = lookaround_id * words_per_la + pos / 64;
         let bit = pos % 64;
         self.computed[word_idx] |= 1u64 << bit;

--- a/src/nfa/tagged/steps.rs
+++ b/src/nfa/tagged/steps.rs
@@ -220,8 +220,7 @@ impl<'a> StepExtractor<'a> {
                     return Vec::new();
                 }
 
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 // Check for greedy loop
                 let target_state = &self.nfa.states[target as usize];
@@ -273,7 +272,7 @@ impl<'a> StepExtractor<'a> {
 
                 // Extract each alternative branch
                 let mut alternatives: Vec<Vec<PatternStep>> = Vec::new();
-                for (_i, &target) in state.epsilon.iter().enumerate() {
+                for &target in state.epsilon.iter() {
                     let mut branch_visited = visited.to_vec();
                     branch_visited[current as usize] = true;
                     let branch_steps = self.extract_branch(target, &mut branch_visited);
@@ -423,8 +422,7 @@ impl<'a> StepExtractor<'a> {
                     return Vec::new();
                 }
 
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 // Check for greedy loop
                 let target_state = &self.nfa.states[target as usize];
@@ -517,7 +515,7 @@ impl<'a> StepExtractor<'a> {
                 // eprintln!("DEBUG extract_branch: actual alternation at state {} with 2 epsilons", current);
                 let mut alternatives: Vec<Vec<PatternStep>> = Vec::new();
                 let mut any_valid = false;
-                for (_i, &target) in state.epsilon.iter().enumerate() {
+                for &target in state.epsilon.iter() {
                     let mut branch_visited = visited.to_vec();
                     branch_visited[current as usize] = true;
                     // Check if this branch can reach the match state
@@ -549,7 +547,7 @@ impl<'a> StepExtractor<'a> {
                 // eprintln!("DEBUG extract_branch: multi-alternation at state {} with {} epsilons", current, state.epsilon.len());
                 let mut alternatives: Vec<Vec<PatternStep>> = Vec::new();
                 let mut any_valid = false;
-                for (_i, &target) in state.epsilon.iter().enumerate() {
+                for &target in state.epsilon.iter() {
                     let mut branch_visited = visited.to_vec();
                     branch_visited[current as usize] = true;
                     // Check if this branch directly reaches match state
@@ -648,8 +646,7 @@ impl<'a> StepExtractor<'a> {
                     return Vec::new();
                 }
 
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 // Check for greedy star/plus pattern: state has transitions to target,
                 // and target has epsilon transitions where one leads back to current state
@@ -800,8 +797,7 @@ impl<'a> StepExtractor<'a> {
                     return Vec::new();
                 }
 
-                let ranges: Vec<ByteRange> =
-                    state.transitions.iter().map(|(r, _)| r.clone()).collect();
+                let ranges: Vec<ByteRange> = state.transitions.iter().map(|(r, _)| *r).collect();
 
                 // Check for repetition patterns - we can't handle these in lookbehind
                 let target_state = &inner_nfa.states[target as usize];
@@ -956,11 +952,7 @@ impl<'a> StepExtractor<'a> {
             return None;
         }
 
-        let ranges: Vec<ByteRange> = loop_state
-            .transitions
-            .iter()
-            .map(|(r, _)| r.clone())
-            .collect();
+        let ranges: Vec<ByteRange> = loop_state.transitions.iter().map(|(r, _)| *r).collect();
 
         // The target should have epsilon back to loop_start (completing the loop)
         let target_state = &inner_nfa.states[target as usize];
@@ -986,10 +978,11 @@ impl<'a> StepExtractor<'a> {
         }
 
         // Simple case: target has single epsilon back to loop_start
-        if target_state.epsilon.len() == 1 && target_state.epsilon[0] == loop_start {
-            if !visited[loop_start as usize] {
-                return Some((ranges, exit_state));
-            }
+        if target_state.epsilon.len() == 1
+            && target_state.epsilon[0] == loop_start
+            && !visited[loop_start as usize]
+        {
+            return Some((ranges, exit_state));
         }
 
         None

--- a/src/nfa/thompson.rs
+++ b/src/nfa/thompson.rs
@@ -86,12 +86,8 @@ impl NfaBuilder {
         let start = self.add_state();
         let mut current = start;
 
-        for (i, &byte) in bytes.iter().enumerate() {
-            let next = if i == bytes.len() - 1 {
-                self.add_state()
-            } else {
-                self.add_state()
-            };
+        for &byte in bytes.iter() {
+            let next = self.add_state();
 
             if let Some(state) = self.nfa.get_mut(current) {
                 state.add_transition(ByteRange::single(byte), next);
@@ -141,11 +137,9 @@ impl NfaBuilder {
                     state.add_transition(range, end);
                 }
             }
-        } else {
-            if let Some(state) = self.nfa.get_mut(start) {
-                for &(lo, hi) in &class.ranges {
-                    state.add_transition(ByteRange::new(lo, hi), end);
-                }
+        } else if let Some(state) = self.nfa.get_mut(start) {
+            for &(lo, hi) in &class.ranges {
+                state.add_transition(ByteRange::new(lo, hi), end);
             }
         }
 

--- a/src/nfa/utf8_automata.rs
+++ b/src/nfa/utf8_automata.rs
@@ -178,7 +178,7 @@ fn compile_3byte(start: u32, end: u32) -> Vec<Utf8Sequence> {
 
     while current <= end {
         // Skip surrogates
-        if current >= 0xD800 && current <= 0xDFFF {
+        if (0xD800..=0xDFFF).contains(&current) {
             current = 0xE000;
             if current > end {
                 break;
@@ -207,7 +207,7 @@ fn compile_3byte(start: u32, end: u32) -> Vec<Utf8Sequence> {
         current = range_end + 1;
 
         // Skip surrogates after the range
-        if current >= 0xD800 && current <= 0xDFFF {
+        if (0xD800..=0xDFFF).contains(&current) {
             current = 0xE000;
         }
     }
@@ -329,7 +329,7 @@ fn compile_4byte_with_fixed_byte12(
 ///
 /// Returns `None` for invalid code points (surrogates or out of range).
 pub fn encode_code_point(cp: u32) -> Option<Vec<u8>> {
-    if cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF) {
+    if cp > 0x10FFFF || (0xD800..=0xDFFF).contains(&cp) {
         return None;
     }
 
@@ -413,20 +413,20 @@ fn complement_code_point_ranges(ranges: &[(u32, u32)]) -> Vec<(u32, u32)> {
                 }
                 if start > 0xDFFF {
                     complement.push((0xE000.max(current), start.saturating_sub(1)));
-                } else if start >= 0xD800 && start <= 0xDFFF {
+                } else if (0xD800..=0xDFFF).contains(&start) {
                     // start is in surrogate range, skip to after
                     current = 0xE000;
                     if current < start {
                         complement.push((current, start.saturating_sub(1)));
                     }
                 }
-            } else if current >= 0xD800 && current <= 0xDFFF {
+            } else if (0xD800..=0xDFFF).contains(&current) {
                 // Current is in surrogate range, skip to after
                 current = 0xE000;
                 if current < start {
                     complement.push((current, start.saturating_sub(1)));
                 }
-            } else if start >= 0xD800 && start <= 0xDFFF {
+            } else if (0xD800..=0xDFFF).contains(&start) {
                 // Start is in surrogate range
                 if current < 0xD800 {
                     complement.push((current, 0xD7FF));
@@ -442,7 +442,7 @@ fn complement_code_point_ranges(ranges: &[(u32, u32)]) -> Vec<(u32, u32)> {
         current = end.saturating_add(1);
 
         // Skip surrogates if we land in them
-        if current >= 0xD800 && current <= 0xDFFF {
+        if (0xD800..=0xDFFF).contains(&current) {
             current = 0xE000;
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -684,7 +684,7 @@ impl<'a> Parser<'a> {
                                 ranges.push(ClassRange::single('-'));
                                 if let Some(code_point_ranges) = unicode_data::get_property(&name) {
                                     for &(start, end) in code_point_ranges {
-                                        if start >= 0xD800 && start <= 0xDFFF {
+                                        if (0xD800..=0xDFFF).contains(&start) {
                                             continue;
                                         }
                                         let start = start.min(0x10FFFF);
@@ -718,7 +718,7 @@ impl<'a> Parser<'a> {
                         // Convert (u32, u32) code point ranges to ClassRange (char-based)
                         for &(start, end) in code_point_ranges {
                             // Skip surrogate range (U+D800-U+DFFF) since they're not valid chars
-                            if start >= 0xD800 && start <= 0xDFFF {
+                            if (0xD800..=0xDFFF).contains(&start) {
                                 continue;
                             }
                             // Clamp end to valid char range
@@ -738,14 +738,14 @@ impl<'a> Parser<'a> {
                                 {
                                     ranges.push(ClassRange::new(s, e));
                                 }
-                            } else if start <= 0xD7FF && end >= 0xD800 && end <= 0xDFFF {
+                            } else if start <= 0xD7FF && (0xD800..=0xDFFF).contains(&end) {
                                 // Range ends in surrogates, truncate
                                 if let (Some(s), Some(e)) =
                                     (char::from_u32(start), char::from_u32(0xD7FF))
                                 {
                                     ranges.push(ClassRange::new(s, e));
                                 }
-                            } else if start >= 0xD800 && start <= 0xDFFF && end > 0xDFFF {
+                            } else if (0xD800..=0xDFFF).contains(&start) && end > 0xDFFF {
                                 // Range starts in surrogates, start from after
                                 if let (Some(s), Some(e)) =
                                     (char::from_u32(0xE000), char::from_u32(end))
@@ -767,7 +767,7 @@ impl<'a> Parser<'a> {
                                 .iter()
                                 .filter(|&&(start, _)| {
                                     // Count how many ranges we actually added
-                                    start < 0xD800 || start > 0xDFFF
+                                    !(0xD800..=0xDFFF).contains(&start)
                                 })
                                 .map(|&(start, end)| {
                                     let start = start.min(0x10FFFF);

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -207,7 +207,7 @@ pub unsafe fn all_ones() -> __m256i {
     _mm256_set1_epi8(-1)
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "x86_64"))]
 mod tests {
     use super::*;
 

--- a/src/simd/memchr.rs
+++ b/src/simd/memchr.rs
@@ -54,13 +54,7 @@ unsafe fn memchr_avx2(needle: u8, haystack: &[u8]) -> Option<usize> {
     }
 
     // Handle remaining bytes (scalar)
-    for i in offset..len {
-        if *haystack.get_unchecked(i) == needle {
-            return Some(i);
-        }
-    }
-
-    None
+    (offset..len).find(|&i| *haystack.get_unchecked(i) == needle)
 }
 
 /// Scalar implementation of memchr.

--- a/src/simd/teddy.rs
+++ b/src/simd/teddy.rs
@@ -251,16 +251,18 @@ impl Teddy {
     /// Scalar search starting from a base offset.
     fn find_scalar_from(&self, haystack: &[u8], base_offset: usize) -> Option<(usize, usize)> {
         for (i, window) in haystack.windows(1).enumerate() {
-            let first_byte = window[0];
             let pos = base_offset + i;
 
-            // Quick nibble check
+            // Quick nibble check (x86_64 only - uses precomputed nibble tables)
             #[cfg(target_arch = "x86_64")]
-            let pattern_mask = self.lo_nibble_table[(first_byte & 0x0F) as usize]
-                & self.hi_nibble_table[(first_byte >> 4) as usize];
+            let pattern_mask = {
+                let first_byte = window[0];
+                self.lo_nibble_table[(first_byte & 0x0F) as usize]
+                    & self.hi_nibble_table[(first_byte >> 4) as usize]
+            };
 
             #[cfg(not(target_arch = "x86_64"))]
-            let pattern_mask = 0xFFu8; // Check all patterns
+            let pattern_mask = 0xFFu8; // Check all patterns on non-x86
 
             if pattern_mask != 0 {
                 for (pat_idx, pattern) in self.patterns.iter().enumerate() {

--- a/src/simd/teddy.rs
+++ b/src/simd/teddy.rs
@@ -211,13 +211,11 @@ impl Teddy {
 
                     // Verify each matching pattern
                     for (pat_idx, pattern) in self.patterns.iter().enumerate() {
-                        if (pattern_mask & (1 << pat_idx)) != 0 {
-                            // First byte matches, verify the rest
-                            if pos + pattern.len() <= len {
-                                if haystack[pos..pos + pattern.len()] == *pattern {
-                                    return Some((pat_idx, pos));
-                                }
-                            }
+                        if (pattern_mask & (1 << pat_idx)) != 0
+                            && pos + pattern.len() <= len
+                            && haystack[pos..pos + pattern.len()] == *pattern
+                        {
+                            return Some((pat_idx, pos));
                         }
                     }
                 }
@@ -271,10 +269,10 @@ impl Teddy {
                         continue;
                     }
 
-                    if i + pattern.len() <= haystack.len() {
-                        if &haystack[i..i + pattern.len()] == pattern.as_slice() {
-                            return Some((pat_idx, pos));
-                        }
+                    if i + pattern.len() <= haystack.len()
+                        && &haystack[i..i + pattern.len()] == pattern.as_slice()
+                    {
+                        return Some((pat_idx, pos));
                     }
                 }
             }

--- a/src/simd/teddy.rs
+++ b/src/simd/teddy.rs
@@ -311,7 +311,7 @@ impl<'a, 'h> Iterator for TeddyIter<'a, 'h> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "x86_64"))]
 mod tests {
     use super::*;
 

--- a/src/simd/tests.rs
+++ b/src/simd/tests.rs
@@ -3,7 +3,7 @@
 //! Tests the interaction between different SIMD components and validates
 //! behavior across various edge cases.
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "x86_64"))]
 mod integration_tests {
     use crate::simd::*;
 

--- a/src/vm/backtracking/engine.rs
+++ b/src/vm/backtracking/engine.rs
@@ -6,7 +6,7 @@ use crate::hir::Hir;
 
 use super::interpreter::BacktrackingVm;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 use super::jit::{compile_backtracking, BacktrackingJit};
 
 /// Backtracking engine that automatically selects the best backend.
@@ -16,7 +16,7 @@ pub struct BacktrackingEngine {
     /// The compiled backtracking VM (interpreter).
     vm: BacktrackingVm,
     /// JIT-compiled version (if available).
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     jit: Option<BacktrackingJit>,
 }
 
@@ -33,12 +33,12 @@ impl BacktrackingEngine {
     pub fn new(hir: &Hir) -> Self {
         let vm = BacktrackingVm::new(hir);
 
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         let jit = compile_backtracking(hir).ok();
 
         Self {
             vm,
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             jit,
         }
     }
@@ -52,7 +52,7 @@ impl BacktrackingEngine {
     /// Finds the first match, returning (start, end).
     #[inline]
     pub fn find(&self, input: &[u8]) -> Option<(usize, usize)> {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         if let Some(ref jit) = self.jit {
             return jit.find(input);
         }
@@ -63,7 +63,7 @@ impl BacktrackingEngine {
     /// Finds a match starting at or after the given position.
     #[inline]
     pub fn find_at(&self, input: &[u8], pos: usize) -> Option<(usize, usize)> {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         if let Some(ref jit) = self.jit {
             return jit.find_at(input, pos);
         }
@@ -74,7 +74,7 @@ impl BacktrackingEngine {
     /// Returns capture groups for the first match.
     #[inline]
     pub fn captures(&self, input: &[u8]) -> Option<Vec<Option<(usize, usize)>>> {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         if let Some(ref jit) = self.jit {
             return jit.captures(input);
         }
@@ -93,13 +93,13 @@ impl BacktrackingEngine {
     }
 
     /// Returns whether JIT is being used.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     pub fn is_jit(&self) -> bool {
         self.jit.is_some()
     }
 
     /// Returns whether JIT is being used (always false without JIT feature).
-    #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+    #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
     pub fn is_jit(&self) -> bool {
         false
     }

--- a/src/vm/backtracking/interpreter/vm.rs
+++ b/src/vm/backtracking/interpreter/vm.rs
@@ -168,8 +168,7 @@ impl BacktrackingVm {
                     if pos < input.len() {
                         let b = input[pos];
                         let mut matched = false;
-                        for i in 0..count as usize {
-                            let (lo, hi) = ranges[i];
+                        for &(lo, hi) in ranges.iter().take(count as usize) {
                             if b >= lo && b <= hi {
                                 matched = true;
                                 break;
@@ -197,8 +196,7 @@ impl BacktrackingVm {
                     if pos < input.len() {
                         let b = input[pos];
                         let mut in_range = false;
-                        for i in 0..count as usize {
-                            let (lo, hi) = ranges[i];
+                        for &(lo, hi) in ranges.iter().take(count as usize) {
                             if b >= lo && b <= hi {
                                 in_range = true;
                                 break;
@@ -344,13 +342,10 @@ impl BacktrackingVm {
                         // Save old value for potential restore
                         if let Some(&frame_start) = slot_stack_frames.last() {
                             // Check if we already saved this slot in current frame
-                            let mut already_saved = false;
-                            for i in frame_start..slot_stack.len() {
-                                if slot_stack[i].0 == slot as u16 {
-                                    already_saved = true;
-                                    break;
-                                }
-                            }
+                            let already_saved = slot_stack
+                                .iter()
+                                .skip(frame_start)
+                                .any(|&(s, _)| s == slot as u16);
                             if !already_saved {
                                 slot_stack.push((slot as u16, slots[slot]));
                             }

--- a/src/vm/backtracking/jit/aarch64.rs
+++ b/src/vm/backtracking/jit/aarch64.rs
@@ -1,0 +1,792 @@
+//! AArch64 (ARM64) code generation for backtracking JIT.
+//!
+//! This module implements a PCRE-style backtracking JIT that generates native AArch64
+//! code for patterns containing backreferences.
+//!
+//! # Register Allocation (AAPCS64)
+//!
+//! | Register | Purpose |
+//! |----------|---------|
+//! | x19 | Input base pointer (callee-saved) |
+//! | x20 | Input length (callee-saved) |
+//! | x21 | Current position in input (callee-saved) |
+//! | x22 | Captures base pointer (callee-saved) |
+//! | x23 | Start position for current match attempt (callee-saved) |
+//! | x24 | Scratch for comparisons (callee-saved) |
+//! | x25 | Loop counter (callee-saved) |
+//! | x26 | Backtrack stack pointer (callee-saved) |
+//! | x29 | Frame pointer |
+//! | x30 | Link register |
+//! | x0-x15 | Scratch / arguments / return |
+
+use crate::error::{Error, ErrorKind, Result};
+use crate::hir::{Hir, HirAnchor, HirClass, HirExpr};
+
+use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
+
+use super::jit::BacktrackingJit;
+
+// ARM64 backtracking JIT enabled
+const ARM64_BACKTRACKING_JIT_ENABLED: bool = true;
+
+/// The backtracking JIT compiler for ARM64.
+pub(super) struct BacktrackingCompiler {
+    /// The assembler.
+    asm: dynasmrt::aarch64::Assembler,
+    /// The HIR to compile.
+    hir: Hir,
+    /// Label for the backtrack handler.
+    backtrack_label: dynasmrt::DynamicLabel,
+    /// Label for successful match.
+    match_success_label: dynasmrt::DynamicLabel,
+    /// Label for no match found.
+    no_match_label: dynasmrt::DynamicLabel,
+    /// Label for trying next start position.
+    next_start_label: dynasmrt::DynamicLabel,
+    /// Number of capture groups.
+    capture_count: u32,
+    /// Current capture index being filled.
+    current_capture: Option<u32>,
+}
+
+impl BacktrackingCompiler {
+    pub(super) fn new(hir: &Hir) -> Result<Self> {
+        let mut asm = dynasmrt::aarch64::Assembler::new().map_err(|e| {
+            Error::new(
+                ErrorKind::Jit(format!("Failed to create assembler: {:?}", e)),
+                "",
+            )
+        })?;
+
+        let backtrack_label = asm.new_dynamic_label();
+        let match_success_label = asm.new_dynamic_label();
+        let no_match_label = asm.new_dynamic_label();
+        let next_start_label = asm.new_dynamic_label();
+
+        Ok(Self {
+            asm,
+            hir: hir.clone(),
+            backtrack_label,
+            match_success_label,
+            no_match_label,
+            next_start_label,
+            capture_count: hir.props.capture_count,
+            current_capture: None,
+        })
+    }
+
+    pub(super) fn compile(mut self) -> Result<BacktrackingJit> {
+        // ARM64 backtracking JIT is disabled until assembly is fully debugged
+        if !ARM64_BACKTRACKING_JIT_ENABLED {
+            return Err(Error::new(
+                ErrorKind::Jit("ARM64 backtracking JIT temporarily disabled".to_string()),
+                "",
+            ));
+        }
+
+        let entry_offset = self.asm.offset();
+
+        self.emit_prologue();
+        self.emit_main_loop()?;
+        self.emit_pattern(&self.hir.expr.clone())?;
+
+        // After pattern matches, jump to success
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; b =>self.match_success_label
+        );
+
+        self.emit_backtrack_handler();
+        self.emit_success_handler();
+
+        let code = self
+            .asm
+            .finalize()
+            .map_err(|e| Error::new(ErrorKind::Jit(format!("Failed to finalize: {:?}", e)), ""))?;
+
+        // ARM64 uses AAPCS64 calling convention (extern "C")
+        let match_fn: unsafe extern "C" fn(*const u8, usize, *mut i64) -> i64 =
+            unsafe { std::mem::transmute(code.ptr(entry_offset)) };
+
+        Ok(BacktrackingJit {
+            code,
+            match_fn,
+            capture_count: self.capture_count,
+        })
+    }
+
+    /// Emits the function prologue.
+    fn emit_prologue(&mut self) {
+        // Function signature: fn(input_ptr: *const u8, input_len: usize, captures: *mut i64) -> i64
+        // AAPCS64: x0 = input_ptr, x1 = input_len, x2 = captures_ptr
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            // Save frame pointer and link register
+            ; stp x29, x30, [sp, #-16]!
+            ; mov x29, sp
+
+            // Save callee-saved registers
+            ; stp x19, x20, [sp, #-16]!
+            ; stp x21, x22, [sp, #-16]!
+            ; stp x23, x24, [sp, #-16]!
+            ; stp x25, x26, [sp, #-16]!
+            ; stp x27, x28, [sp, #-16]!
+
+            // Allocate backtrack stack (4KB) - use mov+sub since 0x1000 > 4095
+            ; mov x9, 0x1000
+            ; sub sp, sp, x9
+
+            // Move arguments to callee-saved registers
+            ; mov x19, x0              // x19 = input_ptr
+            ; mov x20, x1              // x20 = input_len
+            ; mov x22, x2              // x22 = captures_ptr
+            ; mov x23, #0              // x23 = start_pos = 0
+            ; mov x26, sp              // x26 = backtrack stack pointer (bottom)
+
+            // Initialize captures to -1 using x0 as scratch
+            ; movn x0, 0
+        );
+
+        // Initialize all capture slots to -1
+        let num_slots = (self.capture_count as usize + 1) * 2;
+        for slot in 0..num_slots {
+            let offset = (slot * 8) as u32;
+            if offset < 4096 {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; str x0, [x22, offset]
+                );
+            } else {
+                let offset64 = offset as u64;
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; mov x1, offset64
+                    ; str x0, [x22, x1]
+                );
+            }
+        }
+    }
+
+    /// Emits the main loop that tries each start position.
+    fn emit_main_loop(&mut self) -> Result<()> {
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>self.next_start_label
+
+            // Reset captures for new attempt
+            ; movn x0, 0
+        );
+
+        // Reset capture slots to -1
+        let num_slots = (self.capture_count as usize + 1) * 2;
+        for slot in 0..num_slots {
+            let offset = (slot * 8) as u32;
+            if offset < 4096 {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; str x0, [x22, offset]
+                );
+            } else {
+                let offset64 = offset as u64;
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; mov x1, offset64
+                    ; str x0, [x22, x1]
+                );
+            }
+        }
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            // x21 = current position = start_pos
+            ; mov x21, x23
+
+            // Set group 0 start = current position
+            ; str x21, [x22]
+
+            // Reset backtrack stack to bottom
+            ; mov x9, 0x1000
+            ; sub x26, x29, x9
+            ; sub x26, x26, #0x50     // Account for saved registers
+        );
+
+        Ok(())
+    }
+
+    /// Emits code to match the pattern.
+    fn emit_pattern(&mut self, expr: &HirExpr) -> Result<()> {
+        match expr {
+            HirExpr::Empty => Ok(()),
+            HirExpr::Literal(bytes) => self.emit_literal(bytes),
+            HirExpr::Class(class) => self.emit_class(class),
+            HirExpr::UnicodeCpClass(_) => Err(Error::new(
+                ErrorKind::Jit(
+                    "Unicode codepoint classes not supported in backtracking JIT".to_string(),
+                ),
+                "",
+            )),
+            HirExpr::Concat(parts) => {
+                for part in parts {
+                    self.emit_pattern(part)?;
+                }
+                Ok(())
+            }
+            HirExpr::Alt(alternatives) => self.emit_alternation(alternatives),
+            HirExpr::Repeat(repeat) => {
+                self.emit_repetition(&repeat.expr, repeat.min, repeat.max, repeat.greedy)
+            }
+            HirExpr::Capture(capture) => self.emit_capture(capture.index, &capture.expr),
+            HirExpr::Backref(group) => self.emit_backref(*group),
+            HirExpr::Anchor(anchor) => self.emit_anchor(*anchor),
+            HirExpr::Lookaround(_) => Err(Error::new(
+                ErrorKind::Jit("Lookarounds not supported in backtracking JIT".to_string()),
+                "",
+            )),
+        }
+    }
+
+    /// Emits code to match a literal string.
+    fn emit_literal(&mut self, bytes: &[u8]) -> Result<()> {
+        for &byte in bytes {
+            dynasm!(self.asm
+                ; .arch aarch64
+                // Check if we're at end of input
+                ; cmp x21, x20
+                ; b.hs =>self.backtrack_label
+
+                // Load byte at current position
+                ; ldrb w0, [x19, x21]
+
+                // Compare with expected byte
+                ; cmp w0, #(byte as u32)
+                ; b.ne =>self.backtrack_label
+
+                // Advance position
+                ; add x21, x21, #1
+            );
+        }
+        Ok(())
+    }
+
+    /// Emits code to match a character class.
+    fn emit_class(&mut self, class: &HirClass) -> Result<()> {
+        let match_ok = self.asm.new_dynamic_label();
+        let no_match = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            // Check end of input
+            ; cmp x21, x20
+            ; b.hs =>self.backtrack_label
+
+            // Load current byte
+            ; ldrb w0, [x19, x21]
+        );
+
+        // Generate range checks
+        for &(start, end) in &class.ranges {
+            if start == end {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp w0, #(start as u32)
+                    ; b.eq =>match_ok
+                );
+            } else {
+                let next_range = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp w0, #(start as u32)
+                    ; b.lo =>next_range
+                    ; cmp w0, #(end as u32)
+                    ; b.ls =>match_ok
+                    ; =>next_range
+                );
+            }
+        }
+
+        // No range matched
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; b =>no_match
+        );
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>match_ok
+        );
+
+        // Handle negation
+        if class.negated {
+            let done = self.asm.new_dynamic_label();
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; b =>self.backtrack_label
+                ; =>no_match
+                ; add x21, x21, #1
+                ; b =>done
+                ; =>done
+            );
+        } else {
+            let done = self.asm.new_dynamic_label();
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; add x21, x21, #1
+                ; b =>done
+                ; =>no_match
+                ; b =>self.backtrack_label
+                ; =>done
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Emits code for alternation with backtracking.
+    fn emit_alternation(&mut self, alternatives: &[HirExpr]) -> Result<()> {
+        if alternatives.is_empty() {
+            return Ok(());
+        }
+
+        let after_alt = self.asm.new_dynamic_label();
+
+        for (i, alt) in alternatives.iter().enumerate() {
+            let is_last = i == alternatives.len() - 1;
+
+            if !is_last {
+                let try_next = self.asm.new_dynamic_label();
+
+                // Save state for backtracking (32-byte entry)
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; str x21, [x26]             // Save position
+                    ; adr x0, =>try_next
+                    ; str x0, [x26, #8]          // Save resume address
+                    ; str x23, [x26, #16]        // Save start_pos
+                    ; str xzr, [x26, #24]        // Unused slot
+                    ; add x26, x26, #32          // Push
+                );
+
+                self.emit_pattern(alt)?;
+
+                // Success - pop choice point and jump past alternatives
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; sub x26, x26, #32
+                    ; b =>after_alt
+                );
+
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; =>try_next
+                );
+            } else {
+                self.emit_pattern(alt)?;
+            }
+        }
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>after_alt
+        );
+
+        Ok(())
+    }
+
+    /// Emits code for repetition.
+    fn emit_repetition(
+        &mut self,
+        expr: &HirExpr,
+        min: u32,
+        max: Option<u32>,
+        greedy: bool,
+    ) -> Result<()> {
+        let loop_done = self.asm.new_dynamic_label();
+
+        // Exact repetitions {n,n} optimization
+        if let Some(max_val) = max {
+            if min == max_val && min > 0 {
+                return self.emit_exact_repetition(expr, min);
+            }
+        }
+
+        // x25 = iteration counter
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; mov x25, #0
+        );
+
+        if greedy {
+            let loop_start = self.asm.new_dynamic_label();
+            let try_backtrack = self.asm.new_dynamic_label();
+
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; =>loop_start
+            );
+
+            if let Some(max_val) = max {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp x25, #(max_val as u32)
+                    ; b.hs =>loop_done
+                );
+            }
+
+            // Push choice point
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; str x21, [x26]
+                ; adr x0, =>try_backtrack
+                ; str x0, [x26, #8]
+                ; str x23, [x26, #16]
+                ; str x25, [x26, #24]
+                ; add x26, x26, #32
+            );
+
+            let iteration_matched = self.asm.new_dynamic_label();
+            let iteration_backtrack = self.asm.new_dynamic_label();
+            let old_backtrack = self.backtrack_label;
+            self.backtrack_label = iteration_backtrack;
+
+            self.emit_pattern(expr)?;
+
+            self.backtrack_label = old_backtrack;
+
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; b =>iteration_matched
+
+                ; =>iteration_backtrack
+                // Calculate stack bottom
+                ; mov x0, 0x1000
+                ; sub x0, x29, x0
+                ; sub x0, x0, #0x50
+                ; cmp x26, x0
+                ; b.ls >empty_stack
+
+                // Pop and check entry
+                ; sub x26, x26, #32
+                ; ldr x0, [x26, #8]
+                ; adr x1, =>try_backtrack
+                ; cmp x0, x1
+                ; b.ne >not_our_entry
+
+                // Our entry - restore and exit loop
+                ; ldr x21, [x26]
+                ; ldr x23, [x26, #16]
+                ; ldr x25, [x26, #24]
+                ; b =>loop_done
+
+                ; not_our_entry:
+                ; ldr x21, [x26]
+                ; ldr x23, [x26, #16]
+                ; ldr x25, [x26, #24]
+                ; br x0
+
+                ; empty_stack:
+                ; b =>loop_done
+
+                ; =>iteration_matched
+                ; add x25, x25, #1
+                ; b =>loop_start
+
+                ; =>try_backtrack
+            );
+
+            // Update capture end if inside a capture
+            if let Some(cap_idx) = self.current_capture {
+                let end_offset = (cap_idx as u32) * 16 + 8;
+                if end_offset < 4096 {
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; str x21, [x22, #end_offset]
+                    );
+                }
+            }
+
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; cmp x25, #(min as u32)
+                ; b.lo =>self.backtrack_label
+                ; b =>loop_done
+            );
+        } else {
+            // Non-greedy: match minimum first
+            for _ in 0..min {
+                self.emit_pattern(expr)?;
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; add x25, x25, #1
+                );
+            }
+
+            if max.map_or(true, |m| m > min) {
+                let loop_start = self.asm.new_dynamic_label();
+                let try_more = self.asm.new_dynamic_label();
+
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; =>loop_start
+                );
+
+                if let Some(max_val) = max {
+                    dynasm!(self.asm
+                        ; .arch aarch64
+                        ; cmp x25, #(max_val as u32)
+                        ; b.hs =>loop_done
+                    );
+                }
+
+                // Push choice point to try more later
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; str x21, [x26]
+                    ; adr x0, =>try_more
+                    ; str x0, [x26, #8]
+                    ; str x23, [x26, #16]
+                    ; str x25, [x26, #24]
+                    ; add x26, x26, #32
+                    ; b =>loop_done
+
+                    ; =>try_more
+                );
+
+                self.emit_pattern(expr)?;
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; add x25, x25, #1
+                    ; b =>loop_start
+                );
+            }
+        }
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>loop_done
+            ; cmp x25, #(min as u32)
+            ; b.lo =>self.backtrack_label
+        );
+
+        Ok(())
+    }
+
+    /// Emits optimized code for exact repetitions.
+    fn emit_exact_repetition(&mut self, expr: &HirExpr, count: u32) -> Result<()> {
+        let loop_start = self.asm.new_dynamic_label();
+        let count64 = count as u64;
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; mov x25, count64
+            ; =>loop_start
+        );
+
+        self.emit_pattern(expr)?;
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; subs w25, w25, #1
+            ; b.ne =>loop_start
+        );
+
+        Ok(())
+    }
+
+    /// Emits code for a capture group.
+    fn emit_capture(&mut self, index: u32, expr: &HirExpr) -> Result<()> {
+        let start_offset = (index as u32) * 16;
+        let end_offset = start_offset + 8;
+
+        // Record start position
+        if start_offset < 4096 {
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; str x21, [x22, #start_offset]
+            );
+        }
+
+        let old_capture = self.current_capture;
+        self.current_capture = Some(index);
+
+        self.emit_pattern(expr)?;
+
+        self.current_capture = old_capture;
+
+        // Record end position
+        if end_offset < 4096 {
+            dynasm!(self.asm
+                ; .arch aarch64
+                ; str x21, [x22, #end_offset]
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Emits code for a backreference.
+    fn emit_backref(&mut self, group: u32) -> Result<()> {
+        let start_offset = (group as u32) * 16;
+        let end_offset = start_offset + 8;
+        let backref_ok = self.asm.new_dynamic_label();
+
+        dynasm!(self.asm
+            ; .arch aarch64
+            // Load captured text bounds
+            ; ldr x8, [x22, #start_offset]   // x8 = capture_start
+            ; ldr x9, [x22, #end_offset]     // x9 = capture_end
+
+            // Check if capture is valid (not -1)
+            ; cmn x8, #1
+            ; b.eq =>self.backtrack_label
+
+            // Calculate capture length
+            ; sub x10, x9, x8                // x10 = capture_len
+
+            // Empty capture always matches
+            ; cbz x10, =>backref_ok
+
+            // Check if enough input remains
+            ; sub x11, x20, x21              // x11 = remaining
+            ; cmp x10, x11
+            ; b.hi =>self.backtrack_label
+
+            // Set up pointers for comparison
+            ; add x8, x8, x19               // x8 = input + capture_start
+            ; add x9, x19, x21              // x9 = input + current_pos
+
+            // Compare bytes
+            ; mov x24, #0                    // x24 = comparison index
+            ; cmp_loop:
+            ; cmp x24, x10
+            ; b.hs =>backref_ok
+
+            ; ldrb w0, [x8, x24]
+            ; ldrb w1, [x9, x24]
+            ; cmp w0, w1
+            ; b.ne =>self.backtrack_label
+
+            ; add x24, x24, #1
+            ; b <cmp_loop
+
+            ; =>backref_ok
+            ; add x21, x21, x10
+        );
+
+        Ok(())
+    }
+
+    /// Emits code for anchors.
+    fn emit_anchor(&mut self, anchor: HirAnchor) -> Result<()> {
+        match anchor {
+            HirAnchor::Start => {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cbnz x21, =>self.backtrack_label
+                );
+            }
+            HirAnchor::End => {
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp x21, x20
+                    ; b.ne =>self.backtrack_label
+                );
+            }
+            HirAnchor::StartLine => {
+                let ok = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cbz x21, =>ok
+                    ; sub x0, x21, #1
+                    ; ldrb w0, [x19, x0]
+                    ; cmp w0, #0x0a
+                    ; b.ne =>self.backtrack_label
+                    ; =>ok
+                );
+            }
+            HirAnchor::EndLine => {
+                let ok = self.asm.new_dynamic_label();
+                dynasm!(self.asm
+                    ; .arch aarch64
+                    ; cmp x21, x20
+                    ; b.eq =>ok
+                    ; ldrb w0, [x19, x21]
+                    ; cmp w0, #0x0a
+                    ; b.ne =>self.backtrack_label
+                    ; =>ok
+                );
+            }
+            HirAnchor::WordBoundary | HirAnchor::NotWordBoundary => {
+                return Err(Error::new(
+                    ErrorKind::Jit(
+                        "Word boundaries not yet supported in backtracking JIT".to_string(),
+                    ),
+                    "",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Emits the backtrack handler.
+    fn emit_backtrack_handler(&mut self) {
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>self.backtrack_label
+
+            // Calculate stack bottom
+            ; mov x0, 0x1000
+            ; sub x0, x29, x0
+            ; sub x0, x0, #0x50
+            ; cmp x26, x0
+            ; b.ls >try_next_pos
+
+            // Pop backtrack entry
+            ; sub x26, x26, #32
+            ; ldr x21, [x26]           // Restore position
+            ; ldr x0, [x26, #8]        // Get resume address
+            ; ldr x23, [x26, #16]      // Restore start_pos
+            ; ldr x25, [x26, #24]      // Restore extra data
+
+            // Jump to resume address
+            ; br x0
+
+            ; try_next_pos:
+            ; add x23, x23, #1
+            ; cmp x23, x20
+            ; b.hi =>self.no_match_label
+            ; b =>self.next_start_label
+        );
+    }
+
+    /// Emits the success handler.
+    fn emit_success_handler(&mut self) {
+        dynasm!(self.asm
+            ; .arch aarch64
+            ; =>self.match_success_label
+            // Set group 0 end = current position
+            ; str x21, [x22, #8]
+
+            // Return the end position (positive = success)
+            ; mov x0, x21
+            ; b >epilogue
+
+            ; =>self.no_match_label
+            ; movn x0, 0
+
+            ; epilogue:
+            // Deallocate backtrack stack
+            ; mov x9, 0x1000
+            ; add sp, sp, x9
+
+            // Restore callee-saved registers
+            ; ldp x27, x28, [sp], #16
+            ; ldp x25, x26, [sp], #16
+            ; ldp x23, x24, [sp], #16
+            ; ldp x21, x22, [sp], #16
+            ; ldp x19, x20, [sp], #16
+            ; ldp x29, x30, [sp], #16
+            ; ret
+        );
+    }
+}

--- a/src/vm/backtracking/jit/jit.rs
+++ b/src/vm/backtracking/jit/jit.rs
@@ -7,13 +7,20 @@ use crate::hir::Hir;
 
 use dynasmrt::ExecutableBuffer;
 
+#[cfg(target_arch = "x86_64")]
 use super::x86_64::BacktrackingCompiler;
 
+#[cfg(target_arch = "aarch64")]
+use super::aarch64::BacktrackingCompiler;
+
 // Platform-specific function pointer type
-#[cfg(target_os = "windows")]
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
 type MatchFn = unsafe extern "win64" fn(*const u8, usize, *mut i64) -> i64;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
 type MatchFn = unsafe extern "sysv64" fn(*const u8, usize, *mut i64) -> i64;
+// ARM64 uses AAPCS64 on all platforms (extern "C")
+#[cfg(target_arch = "aarch64")]
+type MatchFn = unsafe extern "C" fn(*const u8, usize, *mut i64) -> i64;
 
 /// A compiled backtracking regex.
 pub struct BacktrackingJit {

--- a/src/vm/backtracking/jit/jit.rs
+++ b/src/vm/backtracking/jit/jit.rs
@@ -9,13 +9,19 @@ use dynasmrt::ExecutableBuffer;
 
 use super::x86_64::BacktrackingCompiler;
 
+// Platform-specific function pointer type
+#[cfg(target_os = "windows")]
+type MatchFn = unsafe extern "win64" fn(*const u8, usize, *mut i64) -> i64;
+#[cfg(not(target_os = "windows"))]
+type MatchFn = unsafe extern "sysv64" fn(*const u8, usize, *mut i64) -> i64;
+
 /// A compiled backtracking regex.
 pub struct BacktrackingJit {
     /// Executable code buffer (kept alive for the function pointer).
     #[allow(dead_code)]
     pub(super) code: ExecutableBuffer,
     /// Entry point for matching.
-    pub(super) match_fn: unsafe extern "sysv64" fn(*const u8, usize, *mut i64) -> i64,
+    pub(super) match_fn: MatchFn,
     /// Number of capture groups.
     pub(super) capture_count: u32,
 }

--- a/src/vm/backtracking/jit/mod.rs
+++ b/src/vm/backtracking/jit/mod.rs
@@ -1,8 +1,18 @@
 //! Backtracking JIT compiler.
 //!
-//! Compiles HIR directly to native x86-64 machine code for patterns with backreferences.
+//! Compiles HIR directly to native machine code for patterns with backreferences.
+//!
+//! # Architecture Support
+//!
+//! - **x86_64**: Uses dynasm for code generation
+//! - **aarch64**: Uses dynasm for code generation
 
 mod jit;
+
+#[cfg(target_arch = "x86_64")]
 mod x86_64;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
 
 pub use jit::{compile_backtracking, BacktrackingJit};

--- a/src/vm/backtracking/jit/mod.rs
+++ b/src/vm/backtracking/jit/mod.rs
@@ -7,6 +7,7 @@
 //! - **x86_64**: Uses dynasm for code generation
 //! - **aarch64**: Uses dynasm for code generation
 
+#[allow(clippy::module_inception)]
 mod jit;
 
 #[cfg(target_arch = "x86_64")]

--- a/src/vm/backtracking/jit/x86_64.rs
+++ b/src/vm/backtracking/jit/x86_64.rs
@@ -117,6 +117,11 @@ impl BacktrackingCompiler {
             .finalize()
             .map_err(|e| Error::new(ErrorKind::Jit(format!("Failed to finalize: {:?}", e)), ""))?;
 
+        #[cfg(target_os = "windows")]
+        let match_fn: unsafe extern "win64" fn(*const u8, usize, *mut i64) -> i64 =
+            unsafe { std::mem::transmute(code.ptr(entry_offset)) };
+
+        #[cfg(not(target_os = "windows"))]
         let match_fn: unsafe extern "sysv64" fn(*const u8, usize, *mut i64) -> i64 =
             unsafe { std::mem::transmute(code.ptr(entry_offset)) };
 
@@ -130,7 +135,35 @@ impl BacktrackingCompiler {
     /// Emits the function prologue.
     fn emit_prologue(&mut self) {
         // Function signature: fn(input_ptr: *const u8, input_len: usize, captures: *mut i64) -> i64
-        // Arguments: rdi = input_ptr, rsi = input_len, rdx = captures_ptr
+        // Unix: rdi = input_ptr, rsi = input_len, rdx = captures_ptr
+        // Windows: rcx = input_ptr, rdx = input_len, r8 = captures_ptr
+
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; push rdi              // Callee-saved on Windows
+            ; push rsi              // Callee-saved on Windows
+            ; push rbx
+            ; push r12
+            ; push r13
+            ; push r14
+            ; push r15
+            ; push rbp
+            ; mov rbp, rsp
+
+            // Allocate space for backtrack stack
+            ; sub rsp, 0x1008  // 4KB + 8 bytes for alignment
+
+            // Move Windows args to internal registers
+            ; mov rdi, rcx           // rdi = input_ptr
+            ; mov rsi, rdx           // rsi = input_len
+            ; mov r12, r8            // r12 = captures_ptr
+            ; xor r13d, r13d         // r13 = start_pos = 0
+            ; mov rbx, rsp           // rbx = backtrack stack pointer
+
+            ; mov rax, -1i32 as i64 as i32
+        );
+
+        #[cfg(not(target_os = "windows"))]
         dynasm!(self.asm
             ; push rbx
             ; push r12
@@ -923,6 +956,18 @@ impl BacktrackingCompiler {
             ; pop r13
             ; pop r12
             ; pop rbx
+        );
+
+        // Platform-specific epilogue
+        #[cfg(target_os = "windows")]
+        dynasm!(self.asm
+            ; pop rsi
+            ; pop rdi
+            ; ret
+        );
+
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(self.asm
             ; ret
         );
     }

--- a/src/vm/backtracking/jit/x86_64.rs
+++ b/src/vm/backtracking/jit/x86_64.rs
@@ -695,7 +695,7 @@ impl BacktrackingCompiler {
                 );
             }
 
-            if max.map_or(true, |m| m > min) {
+            if max.is_none_or(|m| m > min) {
                 // Can match more - set up choice points
                 let loop_start = self.asm.new_dynamic_label();
                 let try_more = self.asm.new_dynamic_label();
@@ -897,10 +897,10 @@ impl BacktrackingCompiler {
     /// Emits the backtrack handler.
     ///
     /// All backtrack entries are 32 bytes (stack grows UP):
-    /// - [entry + 0]:  position (rcx)
-    /// - [entry + 8]:  resume address
-    /// - [entry + 16]: start_pos (r13)
-    /// - [entry + 24]: extra data (count for repetition, unused for others)
+    /// - `entry + 0`:  position (rcx)
+    /// - `entry + 8`:  resume address
+    /// - `entry + 16`: start_pos (r13)
+    /// - `entry + 24`: extra data (count for repetition, unused for others)
     fn emit_backtrack_handler(&mut self) {
         dynasm!(self.asm
             ; =>self.backtrack_label

--- a/src/vm/backtracking/mod.rs
+++ b/src/vm/backtracking/mod.rs
@@ -19,14 +19,14 @@ mod engine;
 pub mod interpreter;
 pub(crate) mod shared;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod jit;
 
 // Re-exports
 pub use engine::BacktrackingEngine;
 pub use interpreter::BacktrackingVm;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use jit::{compile_backtracking, BacktrackingJit};
 
 #[cfg(test)]
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(caps[3], Some((2, 3)));
     }
 
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     mod jit_tests {
         use super::*;
         use crate::vm::backtracking::jit::compile_backtracking;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -22,11 +22,11 @@ pub use shift_or::{
     ShiftOrInterpreter, ShiftOrWide,
 };
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use shift_or::JitShiftOr;
 
 // Re-export key types from backtracking module
 pub use backtracking::{BacktrackingEngine, BacktrackingVm};
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use backtracking::{compile_backtracking, BacktrackingJit};

--- a/src/vm/pike/mod.rs
+++ b/src/vm/pike/mod.rs
@@ -24,7 +24,7 @@
 //!
 //! - Sparse set deduplication: O(1) state deduplication using generation counters
 //! - BinaryHeap scheduling: Efficient backref handling with min-heap
-//! - Arc<Nfa> for lookarounds: Avoids expensive NFA cloning
+//! - `Arc<Nfa>` for lookarounds: Avoids expensive NFA cloning
 
 mod engine;
 pub mod interpreter;

--- a/src/vm/pike/shared.rs
+++ b/src/vm/pike/shared.rs
@@ -55,7 +55,7 @@ pub struct PikeVmContext {
     pub next_threads: Vec<Thread>,
     /// Threads waiting for future positions (for backrefs)
     pub future_threads: BinaryHeap<PendingThread>,
-    /// O(1) deduplication: visited[state_id] == generation means state already visited
+    /// O(1) deduplication: `visited[state_id] == generation` means state already visited
     pub visited: Vec<usize>,
     /// Current generation counter (incremented per position/step)
     pub generation: usize,

--- a/src/vm/shift_or/engine.rs
+++ b/src/vm/shift_or/engine.rs
@@ -6,7 +6,7 @@ use crate::hir::Hir;
 
 use super::{ShiftOr, ShiftOrInterpreter};
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 use super::jit::JitShiftOr;
 
 /// Shift-Or engine that automatically selects the best backend.
@@ -16,7 +16,7 @@ pub struct ShiftOrEngine {
     /// The compiled Shift-Or data structure.
     shift_or: ShiftOr,
     /// JIT-compiled version (if available).
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     jit: Option<JitShiftOr>,
 }
 
@@ -34,24 +34,24 @@ impl ShiftOrEngine {
     pub fn from_hir(hir: &Hir) -> Option<Self> {
         let shift_or = ShiftOr::from_hir(hir)?;
 
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         let jit = JitShiftOr::compile(&shift_or);
 
         Some(Self {
             shift_or,
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             jit,
         })
     }
 
     /// Creates a new Shift-Or engine from a pre-compiled ShiftOr.
     pub fn new(shift_or: ShiftOr) -> Self {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         let jit = JitShiftOr::compile(&shift_or);
 
         Self {
             shift_or,
-            #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+            #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
             jit,
         }
     }
@@ -65,7 +65,7 @@ impl ShiftOrEngine {
     /// Finds the first match, returning (start, end).
     #[inline]
     pub fn find(&self, input: &[u8]) -> Option<(usize, usize)> {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         if let Some(ref jit) = self.jit {
             return jit.find(input);
         }
@@ -76,7 +76,7 @@ impl ShiftOrEngine {
     /// Finds a match starting at or after the given position.
     #[inline]
     pub fn find_at(&self, input: &[u8], pos: usize) -> Option<(usize, usize)> {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         if let Some(ref jit) = self.jit {
             return jit.find_at(input, pos);
         }
@@ -87,7 +87,7 @@ impl ShiftOrEngine {
     /// Tries to match at exactly the given position.
     #[inline]
     pub fn try_match_at(&self, input: &[u8], pos: usize) -> Option<(usize, usize)> {
-        #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+        #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
         if let Some(ref jit) = self.jit {
             return jit.try_match_at(input, pos);
         }
@@ -106,13 +106,13 @@ impl ShiftOrEngine {
     }
 
     /// Returns whether JIT is being used.
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     pub fn is_jit(&self) -> bool {
         self.jit.is_some()
     }
 
     /// Returns whether JIT is being used (always false without JIT feature).
-    #[cfg(not(all(feature = "jit", target_arch = "x86_64")))]
+    #[cfg(not(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64"))))]
     pub fn is_jit(&self) -> bool {
         false
     }

--- a/src/vm/shift_or/jit/aarch64.rs
+++ b/src/vm/shift_or/jit/aarch64.rs
@@ -1,0 +1,261 @@
+//! AArch64 (ARM64) code generation for Shift-Or JIT.
+
+use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
+
+use super::super::ShiftOr;
+use super::jit::JitShiftOr;
+
+// ARM64 Shift-Or JIT enabled
+const ARM64_SHIFT_OR_JIT_ENABLED: bool = true;
+
+/// Compiler for Shift-Or JIT on AArch64.
+pub(super) struct ShiftOrJitCompiler;
+
+impl ShiftOrJitCompiler {
+    /// Compiles a ShiftOr matcher to native code.
+    pub(super) fn compile(shift_or: &ShiftOr) -> Option<JitShiftOr> {
+        // ARM64 Shift-Or JIT is disabled until assembly is fully debugged
+        if !ARM64_SHIFT_OR_JIT_ENABLED {
+            return None;
+        }
+
+        // Copy masks to heap FIRST (needs stable address for embedded pointer)
+        let mut masks = Box::new([0u64; 256]);
+        for (i, m) in shift_or.masks.iter().enumerate() {
+            masks[i] = *m;
+        }
+
+        // Copy follow sets to heap FIRST (needs stable address for embedded pointer)
+        let mut follow = Box::new([0u64; 64]);
+        for (i, f) in shift_or.follow.iter().enumerate() {
+            if i < 64 {
+                follow[i] = *f;
+            }
+        }
+
+        // Get stable pointers to embed in JIT code
+        let masks_ptr = masks.as_ptr() as u64;
+        let follow_ptr = follow.as_ptr() as u64;
+
+        let mut ops = dynasmrt::aarch64::Assembler::new().ok()?;
+        let find_offset = Self::emit_find(&mut ops, shift_or, masks_ptr, follow_ptr);
+
+        let code = ops.finalize().ok()?;
+
+        Some(JitShiftOr::new(
+            code,
+            find_offset,
+            masks,
+            follow,
+            shift_or.accept,
+            shift_or.first,
+            shift_or.position_count,
+            shift_or.nullable,
+            shift_or.has_leading_word_boundary,
+            shift_or.has_trailing_word_boundary,
+            shift_or.has_start_anchor,
+            shift_or.has_end_anchor,
+        ))
+    }
+
+    fn emit_find(
+        ops: &mut dynasmrt::aarch64::Assembler,
+        shift_or: &ShiftOr,
+        masks_ptr: u64,
+        follow_ptr: u64,
+    ) -> dynasmrt::AssemblyOffset {
+        // Function signature: fn(input: *const u8, len: usize, accept: u64, first: u64) -> i64
+        // Returns: packed (start << 32 | end) on match, or -1 if no match
+        //
+        // AAPCS64 calling convention:
+        //   x0 = input, x1 = len, x2 = accept, x3 = first
+        //
+        // Register allocation (all callee-saved for internal use):
+        //   x19 = input pointer
+        //   x20 = len
+        //   x21 = accept mask
+        //   x22 = current start position
+        //   x23 = state (inverted: 0 = active position)
+        //   x24 = follow pointer (embedded)
+        //   x25 = masks pointer (embedded)
+        //   x26 = first mask
+        //   x27 = last_match_start
+        //   x28 = last_match_end
+        //
+        // Temporary registers (caller-saved):
+        //   x9-x15 = scratch
+
+        let offset = ops.offset();
+        let _ = shift_or.position_count;
+
+        // Split masks_ptr and follow_ptr into 16-bit chunks for movz/movk
+        let masks_lo = (masks_ptr & 0xFFFF) as u32;
+        let masks_16 = ((masks_ptr >> 16) & 0xFFFF) as u32;
+        let masks_32 = ((masks_ptr >> 32) & 0xFFFF) as u32;
+        let masks_48 = ((masks_ptr >> 48) & 0xFFFF) as u32;
+
+        let follow_lo = (follow_ptr & 0xFFFF) as u32;
+        let follow_16 = ((follow_ptr >> 16) & 0xFFFF) as u32;
+        let follow_32 = ((follow_ptr >> 32) & 0xFFFF) as u32;
+        let follow_48 = ((follow_ptr >> 48) & 0xFFFF) as u32;
+
+        dynasm!(ops
+            ; .arch aarch64
+
+            // Prologue - save callee-saved registers
+            ; stp x29, x30, [sp, #-16]!
+            ; mov x29, sp
+            ; stp x19, x20, [sp, #-16]!
+            ; stp x21, x22, [sp, #-16]!
+            ; stp x23, x24, [sp, #-16]!
+            ; stp x25, x26, [sp, #-16]!
+            ; stp x27, x28, [sp, #-16]!
+
+            // Move arguments to callee-saved registers
+            ; mov x19, x0              // x19 = input
+            ; mov x20, x1              // x20 = len
+            ; mov x21, x2              // x21 = accept
+            ; mov x26, x3              // x26 = first
+
+            // Load embedded pointers (64-bit immediates via movz/movk)
+            ; movz x25, #masks_lo
+            ; movk x25, #masks_16, lsl #16
+            ; movk x25, #masks_32, lsl #32
+            ; movk x25, #masks_48, lsl #48
+
+            ; movz x24, #follow_lo
+            ; movk x24, #follow_16, lsl #16
+            ; movk x24, #follow_32, lsl #32
+            ; movk x24, #follow_48, lsl #48
+
+            // Initialize
+            ; mov x22, #0              // x22 = start position = 0
+            ; movn x28, 0              // x28 = last_match_end = -1
+            ; mov x27, #0              // x27 = last_match_start = 0
+
+            // Outer loop: try each start position
+            ; ->start_loop:
+            ; cmp x22, x20
+            ; b.hs ->done
+
+            // Initialize state for this start position
+            // state = !first | mask[input[start]]
+            ; mvn x23, x26             // x23 = !first
+            ; ldrb w9, [x19, x22]      // w9 = input[start]
+            ; lsl x9, x9, #3           // x9 = byte * 8 (offset into masks array)
+            ; ldr x10, [x25, x9]       // x10 = mask[byte]
+            ; orr x23, x23, x10        // state |= mask[byte]
+
+            // Check immediate match at first byte
+            ; orr x9, x23, x21         // x9 = state | accept
+            ; cmn x9, #1               // compare with -1 (all 1s)
+            ; b.ne ->found_at_start
+
+            // Inner loop: process remaining bytes
+            ; add x10, x22, #1         // x10 = pos = start + 1
+
+            ; ->inner_loop:
+            ; cmp x10, x20
+            ; b.hs ->inner_done
+
+            // Glushkov follow set computation:
+            // reachable = union of follow[i] for all active positions i
+            // state = !reachable | mask[byte]
+            //
+            // Active positions have bit=0 in state (inverted logic)
+            // So active = !state gives us 1 for active positions
+
+            ; mvn x9, x23              // x9 = active positions (1 = active)
+            ; mov x11, #0              // x11 = reachable = 0
+
+            // Iterate through set bits in x9 (active positions)
+            ; ->follow_loop:
+            ; cbz x9, ->follow_done
+
+            // Get lowest set bit position using CLZ on reversed bits
+            // ARM64 has RBIT (reverse bits) + CLZ to find trailing zeros
+            ; rbit x12, x9             // x12 = bit-reversed x9
+            ; clz x12, x12             // x12 = position of lowest set bit in x9
+            ; lsl x13, x12, #3         // x13 = position * 8
+            ; ldr x14, [x24, x13]      // x14 = follow[position]
+            ; orr x11, x11, x14        // reachable |= follow[position]
+
+            // Clear lowest set bit: x9 &= (x9 - 1)
+            ; sub x15, x9, #1
+            ; and x9, x9, x15
+            ; b ->follow_loop
+
+            ; ->follow_done:
+            // Now x11 = reachable (positions that can be reached)
+            // state = !reachable | mask[byte]
+            ; mvn x23, x11             // x23 = !reachable
+            ; ldrb w9, [x19, x10]      // w9 = input[pos]
+            ; lsl x9, x9, #3           // x9 = byte * 8
+            ; ldr x12, [x25, x9]       // x12 = mask[byte]
+            ; orr x23, x23, x12        // state |= mask[byte]
+
+            // Check for match - accept is in x21
+            ; orr x9, x23, x21         // x9 = state | accept
+            ; cmn x9, #1               // compare with -1
+            ; b.ne ->found_in_loop
+
+            // Check if dead state (all 1s = no active positions)
+            ; cmn x23, #1
+            ; b.eq ->inner_done
+
+            // Next byte
+            ; add x10, x10, #1
+            ; b ->inner_loop
+
+            ; ->found_at_start:
+            // Match found at start position (after first byte)
+            ; mov x27, x22             // last_match_start = start
+            ; add x28, x22, #1         // last_match_end = start + 1
+            // Continue to find longer match
+            ; add x10, x22, #1         // pos = start + 1
+            ; b ->inner_loop
+
+            ; ->found_in_loop:
+            // Match found at position x10
+            ; mov x27, x22             // last_match_start = start
+            ; add x28, x10, #1         // last_match_end = pos + 1
+            // Continue to find longest match
+            ; add x10, x10, #1
+            ; b ->inner_loop
+
+            ; ->inner_done:
+            // If we found a match, we're done (first match wins for unanchored)
+            ; cmn x28, #1
+            ; b.ne ->done
+
+            // Try next start position
+            ; add x22, x22, #1
+            ; b ->start_loop
+
+            ; ->done:
+            // Check if we have a match
+            ; cmn x28, #1
+            ; b.eq ->no_match
+
+            // Pack result: (start << 32) | end
+            ; lsl x0, x27, #32         // x0 = start << 32
+            ; orr x0, x0, x28          // x0 = (start << 32) | end
+            ; b ->epilogue
+
+            ; ->no_match:
+            ; movn x0, 0
+
+            ; ->epilogue:
+            // Restore callee-saved registers
+            ; ldp x27, x28, [sp], #16
+            ; ldp x25, x26, [sp], #16
+            ; ldp x23, x24, [sp], #16
+            ; ldp x21, x22, [sp], #16
+            ; ldp x19, x20, [sp], #16
+            ; ldp x29, x30, [sp], #16
+            ; ret
+        );
+
+        offset
+    }
+}

--- a/src/vm/shift_or/jit/jit.rs
+++ b/src/vm/shift_or/jit/jit.rs
@@ -173,7 +173,12 @@ impl JitShiftOr {
     fn call_find(&self, input: &[u8]) -> i64 {
         // OPTIMIZED: Only 4 parameters (masks/follow are embedded in JIT code)
         // Function signature: fn(input, len, accept, first) -> i64
-        let func: extern "C" fn(*const u8, usize, u64, u64) -> i64 =
+        #[cfg(target_os = "windows")]
+        let func: extern "win64" fn(*const u8, usize, u64, u64) -> i64 =
+            unsafe { std::mem::transmute(self.code.ptr(self.find_offset)) };
+
+        #[cfg(not(target_os = "windows"))]
+        let func: extern "sysv64" fn(*const u8, usize, u64, u64) -> i64 =
             unsafe { std::mem::transmute(self.code.ptr(self.find_offset)) };
 
         func(input.as_ptr(), input.len(), self.accept, self.first)

--- a/src/vm/shift_or/jit/jit.rs
+++ b/src/vm/shift_or/jit/jit.rs
@@ -5,7 +5,12 @@
 use dynasmrt::ExecutableBuffer;
 
 use super::super::ShiftOr;
+
+#[cfg(target_arch = "x86_64")]
 use super::x86_64::ShiftOrJitCompiler;
+
+#[cfg(target_arch = "aarch64")]
+use super::aarch64::ShiftOrJitCompiler;
 
 /// JIT-compiled Shift-Or matcher with Glushkov follow sets.
 pub struct JitShiftOr {
@@ -173,12 +178,20 @@ impl JitShiftOr {
     fn call_find(&self, input: &[u8]) -> i64 {
         // OPTIMIZED: Only 4 parameters (masks/follow are embedded in JIT code)
         // Function signature: fn(input, len, accept, first) -> i64
-        #[cfg(target_os = "windows")]
+
+        // x86_64 Windows uses Microsoft x64 ABI
+        #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
         let func: extern "win64" fn(*const u8, usize, u64, u64) -> i64 =
             unsafe { std::mem::transmute(self.code.ptr(self.find_offset)) };
 
-        #[cfg(not(target_os = "windows"))]
+        // x86_64 Unix uses System V AMD64 ABI
+        #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
         let func: extern "sysv64" fn(*const u8, usize, u64, u64) -> i64 =
+            unsafe { std::mem::transmute(self.code.ptr(self.find_offset)) };
+
+        // ARM64 uses AAPCS64 on all platforms (extern "C")
+        #[cfg(target_arch = "aarch64")]
+        let func: extern "C" fn(*const u8, usize, u64, u64) -> i64 =
             unsafe { std::mem::transmute(self.code.ptr(self.find_offset)) };
 
         func(input.as_ptr(), input.len(), self.accept, self.first)

--- a/src/vm/shift_or/jit/mod.rs
+++ b/src/vm/shift_or/jit/mod.rs
@@ -1,13 +1,19 @@
 //! JIT compilation for Shift-Or engine.
 //!
-//! Compiles the Shift-Or bit-parallel NFA to native x86-64 code.
+//! Compiles the Shift-Or bit-parallel NFA to native code.
 //! This eliminates interpreter overhead and keeps all state in registers.
+//!
+//! # Architecture Support
+//!
+//! - **x86_64**: Uses dynasm for code generation
+//! - **aarch64**: Uses dynasm for code generation
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+
 mod jit;
 
-#[cfg(target_arch = "x86_64")]
 pub use jit::JitShiftOr;

--- a/src/vm/shift_or/jit/mod.rs
+++ b/src/vm/shift_or/jit/mod.rs
@@ -14,6 +14,7 @@ mod x86_64;
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 
+#[allow(clippy::module_inception)]
 mod jit;
 
 pub use jit::JitShiftOr;

--- a/src/vm/shift_or/jit/x86_64.rs
+++ b/src/vm/shift_or/jit/x86_64.rs
@@ -62,11 +62,9 @@ impl ShiftOrJitCompiler {
         // Masks and follow pointers are EMBEDDED in the JIT code (movabs instructions)
         // This saves 2 parameter slots and 2 register moves in prologue.
         //
-        // Register allocation (System V AMD64 ABI):
-        //   rdi = input pointer
-        //   rsi = input length
-        //   rdx = accept mask
-        //   rcx = first mask
+        // Register allocation:
+        //   Unix (System V AMD64): rdi=input, rsi=len, rdx=accept, rcx=first
+        //   Windows (Microsoft x64): rcx=input, rdx=len, r8=accept, r9=first
         //
         // Working registers:
         //   r10 = current start position being tried
@@ -83,6 +81,30 @@ impl ShiftOrJitCompiler {
         let offset = ops.offset();
         let _ = shift_or.position_count;
 
+        // Platform-specific prologue
+        #[cfg(target_os = "windows")]
+        dynasm!(ops
+            ; .arch x64
+            // Prologue - save callee-saved registers (including RDI/RSI on Windows)
+            ; push rdi
+            ; push rsi
+            ; push rbx
+            ; push r12
+            ; push r13
+            ; push r14
+            ; push r15
+            ; sub rsp, 24           // Allocate stack space for saved values
+
+            // Windows x64: rcx=input, rdx=len, r8=accept, r9=first
+            ; mov r14, rcx           // r14 = input
+            ; mov r15, rdx           // r15 = len
+            ; mov rbx, QWORD masks_ptr as i64  // rbx = masks (EMBEDDED!)
+            ; mov r12, QWORD follow_ptr as i64 // r12 = follow (EMBEDDED!)
+            ; mov r13, r8            // r13 = accept
+            ; mov [rsp], r9          // [rsp] = first
+        );
+
+        #[cfg(not(target_os = "windows"))]
         dynasm!(ops
             ; .arch x64
             // Prologue - save callee-saved registers
@@ -93,14 +115,16 @@ impl ShiftOrJitCompiler {
             ; push r15
             ; sub rsp, 24           // Allocate stack space for saved values
 
-            // Save arguments and load embedded pointers
+            // Unix: rdi=input, rsi=len, rdx=accept, rcx=first
             ; mov r14, rdi           // r14 = input
             ; mov r15, rsi           // r15 = len
             ; mov rbx, QWORD masks_ptr as i64  // rbx = masks (EMBEDDED!)
             ; mov r12, QWORD follow_ptr as i64 // r12 = follow (EMBEDDED!)
             ; mov r13, rdx           // r13 = accept (was r8, now rdx)
             ; mov [rsp], rcx         // [rsp] = first (was r9, now rcx)
+        );
 
+        dynasm!(ops
             // Initialize - match state on stack (less frequently accessed)
             ; xor r10d, r10d         // r10 = start position = 0
             ; mov QWORD [rsp+16], -1 // last_match_end = -1
@@ -227,6 +251,18 @@ impl ShiftOrJitCompiler {
             ; pop r13
             ; pop r12
             ; pop rbx
+        );
+
+        // Platform-specific epilogue
+        #[cfg(target_os = "windows")]
+        dynasm!(ops
+            ; pop rsi
+            ; pop rdi
+            ; ret
+        );
+
+        #[cfg(not(target_os = "windows"))]
+        dynasm!(ops
             ; ret
         );
 

--- a/src/vm/shift_or/mod.rs
+++ b/src/vm/shift_or/mod.rs
@@ -23,7 +23,7 @@ mod engine;
 pub mod interpreter;
 mod shared;
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub mod jit;
 
 // Re-exports
@@ -31,7 +31,7 @@ pub use engine::ShiftOrEngine;
 pub use interpreter::ShiftOrInterpreter;
 pub use shared::{is_shift_or_compatible, is_shift_or_wide_compatible, ShiftOr, ShiftOrWide};
 
-#[cfg(all(feature = "jit", target_arch = "x86_64"))]
+#[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub use jit::JitShiftOr;
 
 #[cfg(test)]
@@ -208,7 +208,7 @@ mod tests {
         assert!(make_shift_or(r"a{1,3}?b").is_none());
     }
 
-    #[cfg(all(feature = "jit", target_arch = "x86_64"))]
+    #[cfg(all(feature = "jit", any(target_arch = "x86_64", target_arch = "aarch64")))]
     mod jit_tests {
         use super::*;
 

--- a/src/vm/shift_or/mod.rs
+++ b/src/vm/shift_or/mod.rs
@@ -357,7 +357,7 @@ mod tests {
             let so = make_wide(&pattern).unwrap();
 
             // Match at the start
-            let input = format!("{}", "a".repeat(100));
+            let input = "a".repeat(100);
             assert_eq!(so.find(input.as_bytes()), Some((0, 100)));
 
             // Match after prefix

--- a/tests/patterns/tokenization.rs
+++ b/tests/patterns/tokenization.rs
@@ -90,7 +90,7 @@ fn test_split_on_whitespace() {
         .filter(|s| !s.is_empty())
         .collect();
 
-    assert!(parts.len() >= 1);
+    assert!(!parts.is_empty());
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn test_word_after_whitespace() {
         .collect();
     assert!(matches.contains(&"world"));
     assert!(matches.contains(&"test"));
-    assert!(!matches.iter().any(|&m| m == "hello")); // First word has no preceding space
+    assert!(!matches.contains(&"hello")); // First word has no preceding space
 }
 
 #[test]
@@ -518,7 +518,7 @@ fn test_mixed_script_word_segmentation() {
     let segments: Vec<_> = re.find_iter(text).map(|m| m.as_str()).collect();
 
     // Should segment based on script boundaries
-    assert!(segments.len() >= 1);
+    assert!(!segments.is_empty());
 }
 
 // =============================================================================

--- a/tests/perf_backref.rs
+++ b/tests/perf_backref.rs
@@ -6,7 +6,7 @@
 use std::time::Instant;
 
 fn generate_code_data(target_size: usize) -> String {
-    let code_snippets = vec![
+    let code_snippets = [
         r#"let x = "hello world";"#,
         r#"const y = 'single quoted string';"#,
         r#"var z = "escaped \"quotes\" inside";"#,


### PR DESCRIPTION
## Summary

- Add Windows x64 ABI support with proper calling convention handling
- Add complete ARM64 (AArch64) JIT compilation support across all JIT engines
- Add cross-platform CI workflows for Linux (x86-64, ARM64), macOS (x86-64, ARM64), and Windows (x64)
- Implement greedy codepoint matching with backtracking for AArch64

## Platform Support

| Platform | JIT Support | SIMD Support |
|----------|-------------|--------------|
| Linux x86-64 | ✓ | ✓ (AVX2) |
| Linux ARM64 | ✓ | ✗ |
| macOS x86-64 | ✓ | ✓ (AVX2) |
| macOS ARM64 (Apple Silicon) | ✓ | ✗ |
| Windows x86-64 | ✓ | ✓ (AVX2) |

## Changes

### New Platform Support
- **Windows x64**: Implements Windows calling convention (rcx, rdx, r8, r9 for args, different volatile registers)
- **ARM64 (AArch64)**: Full JIT support for Apple Silicon, Linux ARM64
  - DFA JIT (`src/jit/aarch64.rs`)
  - Tagged NFA JIT (`src/nfa/tagged/jit/aarch64.rs`)
  - Backtracking JIT (`src/vm/backtracking/jit/aarch64.rs`)
  - Shift-Or JIT (`src/vm/shift_or/jit/aarch64.rs`)

### Architecture
- New `calling_convention.rs` module abstracts platform-specific ABI details
- Unified codegen helpers work across x86-64 and AArch64

### CI
- `.github/workflows/ci.yml`: General CI for all platforms
- `.github/workflows/jit.yml`: JIT-specific tests on Linux (x86-64, ARM64), macOS (x86-64, ARM64), and Windows

### Documentation
- Updated README.md with platform support table
- Updated docs/architecture.md, engine_structure.md, features.md for ARM64

## Test plan

- [x] CI passes on Linux x86-64
- [x] CI passes on Linux ARM64
- [x] CI passes on macOS x86-64
- [x] CI passes on macOS ARM64 (Apple Silicon)
- [x] CI passes on Windows x64